### PR TITLE
Route all outbound traffic through the configured proxy

### DIFF
--- a/.claire/worktrees/spa-foundation/web/src/App.svelte
+++ b/.claire/worktrees/spa-foundation/web/src/App.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { currentPath, startRouter } from './lib/router.svelte';
+  import AppShell from './routes/AppShell.svelte';
+  import Dashboard from './routes/Dashboard.svelte';
+
+  let teardown: (() => void) | undefined;
+  onMount(() => { teardown = startRouter(); });
+  onDestroy(() => teardown?.());
+</script>
+
+<AppShell>
+  {#if currentPath() === '/'}
+    <Dashboard />
+  {/if}
+</AppShell>

--- a/.claire/worktrees/spa-foundation/web/src/routes/AccountTwitchDevice.test.ts
+++ b/.claire/worktrees/spa-foundation/web/src/routes/AccountTwitchDevice.test.ts
@@ -1,0 +1,1 @@
+placeholder

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -166,6 +166,11 @@ func run() error {
 	if proxyEnabled && proxyURL != "" {
 		effectiveProxy = proxyURL
 	}
+	if effectiveProxy != "" {
+		if _, err := netutil.ProxyDialer(effectiveProxy); err != nil {
+			return fmt.Errorf("proxy enabled but misconfigured (%s): %w", maskProxyURL(effectiveProxy), err)
+		}
+	}
 
 	// Kick runs over the pure-HTTP utls transport (Chrome TLS fingerprint) and
 	// no longer needs the chromedp sidecar for data — Kick's API 403s any
@@ -275,7 +280,7 @@ func run() error {
 		} else {
 			fallback = &notify.NoopNotifier{Logger: logger}
 		}
-		routed := notify.NewAccountRouted(fallback, resolver, filter)
+		routed := notify.NewAccountRouted(fallback, resolver, filter, proxyTransport)
 		routed.Username = botUsername
 		routed.AvatarURL = avatarURL
 		return routed

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -162,6 +162,10 @@ func run() error {
 		safeURL := maskProxyURL(proxyURL)
 		logger.Info("proxy enabled", "url", safeURL)
 	}
+	effectiveProxy := ""
+	if proxyEnabled && proxyURL != "" {
+		effectiveProxy = proxyURL
+	}
 
 	// Kick runs over the pure-HTTP utls transport (Chrome TLS fingerprint) and
 	// no longer needs the chromedp sidecar for data — Kick's API 403s any
@@ -177,6 +181,7 @@ func run() error {
 		kickOpts = append(kickOpts, kick.WithSidecarAutoCreate(cfg.KickSidecarImage, cfg.KickSidecarNetwork))
 		logger.Info("kick sidecar auto-create enabled", "image", cfg.KickSidecarImage, "network", cfg.KickSidecarNetwork)
 	}
+	kickOpts = append(kickOpts, kick.WithProxy(effectiveProxy))
 	kickBackend = kick.New(browserClient, dockerCtl, cfg.KickSidecarTemplate, cfg.KickSidecarPort, 10*time.Minute, kickOpts...)
 	// Watch path is operator-selectable (Settings → Experimental). "browser"
 	// (default) drives a real IVS <video> in the sidecar. "ws" is the
@@ -207,7 +212,13 @@ func run() error {
 	// only needs the beacon transport, not the full watch stack.
 	var twitchBackend *twitch.Backend
 	if proxyTransport != nil {
-		twitchBackend = twitch.NewWithTransport(proxyTransport)
+		bk, err := twitch.NewWithProxy(proxyTransport, effectiveProxy)
+		if err != nil {
+			logger.Warn("twitch: proxy-aware backend failed, falling back to non-proxied PubSub", "err", err)
+			twitchBackend = twitch.NewWithTransport(proxyTransport)
+		} else {
+			twitchBackend = bk
+		}
 	} else {
 		twitchBackend = twitch.New()
 	}
@@ -312,7 +323,18 @@ func run() error {
 			if bk, ok := twitchBackends[a.ID]; ok {
 				return bk, true
 			}
-			bk := twitch.New()
+			var bk *twitch.Backend
+			if proxyTransport != nil {
+				pbk, err := twitch.NewWithProxy(proxyTransport, effectiveProxy)
+				if err != nil {
+					logger.Warn("twitch: proxy-aware backend failed for account, falling back to non-proxied", "account", a.ID, "err", err)
+					bk = twitch.New()
+				} else {
+					bk = pbk
+				}
+			} else {
+				bk = twitch.New()
+			}
 			twitchBackends[a.ID] = bk
 			return bk, true
 		}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to GrubDrops.
 
 ## [Unreleased]
 
+### Fixed
+
+- **All outbound traffic now honours the proxy.** Kick's Chrome-fingerprinted
+  HTTP and WebSocket paths, Twitch PubSub, per-account Twitch, Discord webhooks,
+  and the Kick browser sidecar previously bypassed the configured proxy. They
+  now tunnel through it (SOCKS5 or HTTP CONNECT) with the TLS fingerprint
+  unchanged. Restart to apply.
+
 ## [1.3.6] — 2026-07-01
 
 ### Added

--- a/docs/superpowers/plans/2026-07-01-proxy-bypass-fix.md
+++ b/docs/superpowers/plans/2026-07-01-proxy-bypass-fix.md
@@ -1,0 +1,691 @@
+# Proxy Bypass Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route every outbound connection through the configured global proxy — Kick utls HTTP, Kick WebSocket, Twitch PubSub, per-account Twitch HTTP, Discord webhooks, and the Kick browser sidecar — closing the "not all traffic is routed" bug.
+
+**Architecture:** Add one TCP-tunnel primitive in `netutil` (SOCKS5 via `x/net/proxy`, HTTP via `CONNECT`) that returns a `net.Conn` straight to the target host. Every custom dialer (utls, websocket) swaps its raw `net.Dialer` for this primitive, then layers utls/TLS on top unchanged — the Chrome fingerprint is byte-for-byte identical. The sidecar gets a `--proxy-server` Chrome flag. All fed one effective proxy URL, read once at startup.
+
+**Tech Stack:** Go, `github.com/refraction-networking/utls`, `golang.org/x/net/proxy`, `github.com/coder/websocket` or `gorilla/websocket` (as used in `pubsub.go`/`wswatch.go`), chromedp sidecars via `internal/dockerctl`.
+
+## Global Constraints
+
+- Proxy is **global-only**, read once at startup; **restart to apply**. Do not add live-reload.
+- Proxy schemes supported: `http://`, `https://`, `socks5://` (match `netutil.NewTransport`).
+- **Never terminate TLS at the proxy.** Tunnel at the TCP layer only, then hand the `net.Conn` to `utls.UClient` / the websocket dialer unchanged — the Chrome TLS fingerprint must not change (Kick's Cloudflare check depends on it).
+- **Fail loud:** if the proxy is enabled but a dial fails, the request errors (existing backoff retries). Never silently fall back to a direct connection.
+- Never add a `Client-Integrity` header to Twitch (unrelated but a standing repo rule).
+- `gofmt -w` before every commit; CI has a gofmt gate.
+
+---
+
+### Task 1: `netutil.ProxyDialer` primitive
+
+**Files:**
+- Create: `internal/netutil/dialer.go`
+- Test: `internal/netutil/dialer_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)`
+  - `func ProxyDialer(proxyURL string) (DialContextFunc, error)` — empty `proxyURL` returns a direct `net.Dialer`-backed func; `socks5://` uses `proxy.SOCKS5`; `http(s)://` uses an HTTP CONNECT tunnel; unsupported scheme returns an error.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/netutil/dialer_test.go
+package netutil
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// echoServer starts a TCP server that writes "hello" to any client and returns its addr.
+func echoServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_, _ = c.Write([]byte("hello"))
+			c.Close()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// httpConnectProxy starts a minimal HTTP CONNECT proxy that tunnels to the
+// requested target and records that it was used. Returns proxy addr + a func
+// reporting how many CONNECTs it served.
+func httpConnectProxy(t *testing.T) (addr string, connects func() int) {
+	t.Helper()
+	var n int
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			client, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				br := bufio.NewReader(client)
+				req, err := http.ReadRequest(br)
+				if err != nil || req.Method != http.MethodConnect {
+					client.Close()
+					return
+				}
+				n++
+				target, err := net.Dial("tcp", req.Host)
+				if err != nil {
+					client.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+					client.Close()
+					return
+				}
+				client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+				go io.Copy(target, br)
+				io.Copy(client, target)
+				client.Close()
+				target.Close()
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() int { return n }
+}
+
+func readAll(t *testing.T, c net.Conn) string {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	b, _ := io.ReadAll(c)
+	return string(b)
+}
+
+func TestProxyDialer_DirectWhenEmpty(t *testing.T) {
+	target := echoServer(t)
+	dial, err := ProxyDialer("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := dial(context.Background(), "tcp", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if got := readAll(t, c); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestProxyDialer_HTTPConnectTunnel(t *testing.T) {
+	target := echoServer(t)
+	proxyAddr, connects := httpConnectProxy(t)
+	dial, err := ProxyDialer("http://" + proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := dial(context.Background(), "tcp", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if got := readAll(t, c); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+	if connects() == 0 {
+		t.Fatal("proxy was not used — traffic bypassed it")
+	}
+}
+
+func TestProxyDialer_UnsupportedScheme(t *testing.T) {
+	if _, err := ProxyDialer("ftp://nope:1"); err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+}
+
+func TestProxyDialer_SOCKS5(t *testing.T) {
+	// Uses a tiny in-test SOCKS5 server is heavy; instead assert construction
+	// succeeds for a socks5 URL (dial exercised in staging). A bad host still
+	// constructs — dial-time failure is the fail-loud path.
+	if _, err := ProxyDialer("socks5://127.0.0.1:1080"); err != nil {
+		t.Fatalf("socks5 construction should succeed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/netutil/ -run TestProxyDialer -v`
+Expected: FAIL / build error — `ProxyDialer` undefined.
+
+- [ ] **Step 3: Implement `ProxyDialer`**
+
+```go
+// internal/netutil/dialer.go
+package netutil
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// DialContextFunc dials a TCP connection to addr, optionally tunneled through a
+// proxy. The returned conn speaks directly to the target host, so callers layer
+// utls/TLS/HTTP on top exactly as they would for a direct connection.
+type DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// ProxyDialer returns a dialer for proxyURL. Empty → direct. socks5:// →
+// golang.org/x/net/proxy. http(s):// → HTTP CONNECT tunnel. Unsupported schemes
+// return an error so startup can surface a misconfiguration.
+func ProxyDialer(proxyURL string) (DialContextFunc, error) {
+	base := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	if proxyURL == "" {
+		return base.DialContext, nil
+	}
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse proxy url: %w", err)
+	}
+	switch parsed.Scheme {
+	case "socks5":
+		return func(ctx context.Context, network, addr string) (net.Conn, error) {
+			d, err := proxy.SOCKS5("tcp", parsed.Host, nil, base)
+			if err != nil {
+				return nil, fmt.Errorf("socks5 dialer: %w", err)
+			}
+			if cd, ok := d.(proxy.ContextDialer); ok {
+				return cd.DialContext(ctx, network, addr)
+			}
+			// Fallback: run blocking Dial with ctx cancellation.
+			type res struct {
+				c net.Conn
+				e error
+			}
+			ch := make(chan res, 1)
+			go func() { c, e := d.Dial(network, addr); ch <- res{c, e} }()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case r := <-ch:
+				return r.c, r.e
+			}
+		}, nil
+	case "http", "https":
+		return func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := base.DialContext(ctx, "tcp", parsed.Host)
+			if err != nil {
+				return nil, fmt.Errorf("dial proxy: %w", err)
+			}
+			req := &http.Request{
+				Method: http.MethodConnect,
+				URL:    &url.URL{Opaque: addr},
+				Host:   addr,
+				Header: make(http.Header),
+			}
+			if parsed.User != nil {
+				if pw, ok := parsed.User.Password(); ok {
+					req.SetBasicAuth(parsed.User.Username(), pw)
+				}
+			}
+			if err := req.Write(conn); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("write CONNECT: %w", err)
+			}
+			br := bufio.NewReader(conn)
+			resp, err := http.ReadResponse(br, req)
+			if err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("read CONNECT response: %w", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				conn.Close()
+				return nil, fmt.Errorf("proxy CONNECT failed: %s", resp.Status)
+			}
+			return conn, nil
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported proxy scheme %q", parsed.Scheme)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/netutil/ -v`
+Expected: PASS (all four).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/netutil/
+git add internal/netutil/dialer.go internal/netutil/dialer_test.go
+git commit -m "feat(netutil): ProxyDialer TCP-tunnel primitive (socks5 + http CONNECT)"
+```
+
+---
+
+### Task 2: Kick `WithProxy` option + utls HTTP doer
+
+**Files:**
+- Modify: `internal/platform/kick/backend.go` (options struct, `WithProxy`, `New`)
+- Modify: `internal/platform/kick/transport.go` (`httpDoer` holds dialer; `connFor` uses it)
+- Test: `internal/platform/kick/transport_test.go`
+
+**Interfaces:**
+- Consumes: `netutil.ProxyDialer`, `netutil.DialContextFunc`.
+- Produces: `func WithProxy(proxyURL string) Option`; `newHTTPDoer(dial netutil.DialContextFunc) *httpDoer` (dial nil → direct).
+
+- [ ] **Step 1: Write the failing test** — assert `httpDoer` dials through an injected dialer.
+
+```go
+// internal/platform/kick/transport_test.go
+package kick
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+func TestHTTPDoer_UsesInjectedDialer(t *testing.T) {
+	var used int32
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&used, 1)
+		return nil, context.Canceled // short-circuit; we only assert it was called
+	}
+	d := newHTTPDoer(dial)
+	_, _ = d.connFor(context.Background(), "web.kick.com")
+	if atomic.LoadInt32(&used) == 0 {
+		t.Fatal("httpDoer did not use the injected dialer")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/platform/kick/ -run TestHTTPDoer_UsesInjectedDialer -v`
+Expected: FAIL — `newHTTPDoer` takes no args.
+
+- [ ] **Step 3: Implement**
+
+In `transport.go`, add a `dial netutil.DialContextFunc` field to `httpDoer`; change `newHTTPDoer` to accept it (default to a direct `net.Dialer` when nil); in `connFor` replace:
+
+```go
+	var dialer net.Dialer
+	tcp, err := dialer.DialContext(dialCtx, "tcp", host+":443")
+```
+with:
+```go
+	tcp, err := d.dial(dialCtx, "tcp", host+":443")
+```
+
+and in `newHTTPDoer`:
+```go
+func newHTTPDoer(dial netutil.DialContextFunc) *httpDoer {
+	if dial == nil {
+		var nd net.Dialer
+		dial = nd.DialContext
+	}
+	return &httpDoer{timeout: 20 * time.Second, conns: map[string]*cachedConn{}, dial: dial}
+}
+```
+
+In `backend.go`: add `proxyURL string` to the `options` struct, add `WithProxy`, and in `New` build the dialer and pass it to `newHTTPDoer`:
+```go
+func WithProxy(proxyURL string) Option { return func(o *options) { o.proxyURL = proxyURL } }
+```
+```go
+	dial, err := netutil.ProxyDialer(o.proxyURL)
+	if err != nil {
+		slog.Warn("kick: bad proxy url, using direct", "err", err)
+		dial = nil
+	}
+	// ... wherever the httpDoer is constructed:
+	doer := newHTTPDoer(dial)
+```
+(Find the existing `newHTTPDoer(...)` call site in `New`/backend init and pass `dial`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/platform/kick/ -run TestHTTPDoer_UsesInjectedDialer -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/platform/kick/
+git add internal/platform/kick/backend.go internal/platform/kick/transport.go internal/platform/kick/transport_test.go
+git commit -m "feat(kick): route utls HTTP doer through proxy via WithProxy option"
+```
+
+---
+
+### Task 3: Kick WebSocket dial through proxy
+
+**Files:**
+- Modify: `internal/platform/kick/wswatch.go` (`newUTLSConn`, `wsHTTPClient`, `wsDialer`)
+
+**Interfaces:**
+- Consumes: `netutil.DialContextFunc` from Task 2's backend.
+- Produces: package-level `var wsProxyDial netutil.DialContextFunc` set once at backend construction; `newUTLSConn` uses it (nil → direct `net.Dialer`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// append to internal/platform/kick/transport_test.go
+func TestNewUTLSConn_UsesProxyDial(t *testing.T) {
+	var used int32
+	old := wsProxyDial
+	t.Cleanup(func() { wsProxyDial = old })
+	wsProxyDial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&used, 1)
+		return nil, context.Canceled
+	}
+	_, _ = newUTLSConn(context.Background(), "tcp", "web.kick.com:443")
+	if atomic.LoadInt32(&used) == 0 {
+		t.Fatal("newUTLSConn did not use wsProxyDial")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/platform/kick/ -run TestNewUTLSConn_UsesProxyDial -v`
+Expected: FAIL — `wsProxyDial` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `wswatch.go`, add:
+```go
+// wsProxyDial is the TCP dialer for the WS utls path, set once at backend
+// construction (WithProxy). Nil means direct.
+var wsProxyDial netutil.DialContextFunc
+```
+In `newUTLSConn`, replace:
+```go
+	d := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	raw, err := d.DialContext(ctx, network, addr)
+```
+with:
+```go
+	dial := wsProxyDial
+	if dial == nil {
+		d := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+		dial = d.DialContext
+	}
+	raw, err := dial(ctx, network, addr)
+```
+In `backend.go` `New` (Task 2), after building `dial`, set `wsProxyDial = dial` so the WS globals tunnel through the same proxy.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/platform/kick/ -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/platform/kick/
+git add internal/platform/kick/wswatch.go internal/platform/kick/backend.go internal/platform/kick/transport_test.go
+git commit -m "feat(kick): tunnel WS utls dial through the configured proxy"
+```
+
+---
+
+### Task 4: Twitch PubSub + per-account backend through proxy
+
+**Files:**
+- Modify: `internal/platform/twitch/pubsub.go` (`PubSubClient` gets a dialer; `dialAndPump` uses it)
+- Modify: `internal/platform/twitch/backend.go` (thread proxyURL to the PubSub client; confirm `NewWithTransport` path)
+- Test: `internal/platform/twitch/pubsub_test.go`
+
+**Interfaces:**
+- Consumes: `netutil.ProxyDialer`.
+- Produces: `PubSubClient` honoring an injected `netutil.DialContextFunc` as `websocket.Dialer.NetDialContext`.
+
+- [ ] **Step 1: Write the failing test** — a PubSub client built with a proxy dialer uses it when dialing.
+
+```go
+// internal/platform/twitch/pubsub_test.go
+package twitch
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPubSub_UsesProxyDial(t *testing.T) {
+	var used int32
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&used, 1)
+		return nil, context.Canceled
+	}
+	p := newPubSubClientWithDial(dial) // see Step 3 for constructor
+	_ = p.dialAndPump(context.Background())
+	if atomic.LoadInt32(&used) == 0 {
+		t.Fatal("PubSub did not use the injected dialer")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/platform/twitch/ -run TestPubSub_UsesProxyDial -v`
+Expected: FAIL — `newPubSubClientWithDial` undefined.
+
+- [ ] **Step 3: Implement**
+
+Add a `dial netutil.DialContextFunc` field to `PubSubClient` and a constructor/param that accepts it (mirror the existing constructor; the plan's implementer must read `pubsub.go` for the current constructor name — add `newPubSubClientWithDial(dial netutil.DialContextFunc) *PubSubClient` or extend the existing one with the dialer). In `dialAndPump`, replace:
+```go
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+```
+with:
+```go
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	if p.dial != nil {
+		dialer.NetDialContext = p.dial
+	}
+```
+In `backend.go`, thread `proxyURL` from the constructor to the PubSub client (build the dialer via `netutil.ProxyDialer`). Because per-account backends are built at `cmd/miner/main.go:315`, the constructor must accept the proxy so those honor it too (Task 6).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/platform/twitch/ -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/platform/twitch/
+git add internal/platform/twitch/pubsub.go internal/platform/twitch/backend.go internal/platform/twitch/pubsub_test.go
+git commit -m "feat(twitch): route PubSub websocket dial through the proxy"
+```
+
+---
+
+### Task 5: Kick sidecar `--proxy-server`
+
+**Files:**
+- Modify: `internal/platform/kick/backend.go` (`WithSidecarAutoCreate` or a sibling receives proxyURL) and the sidecar container-create path (read the current create code to find where Chrome args/cmd are set).
+- Test: cover the arg-building helper if one exists; otherwise assert `New(..., WithProxy(url), WithSidecarAutoCreate(...))` stores the proxy for the create path.
+
+**Interfaces:**
+- Consumes: the effective proxy URL already on the backend `options` (Task 2).
+- Produces: each auto-created sidecar container command includes `--proxy-server=<proxyURL>` when a proxy is set.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/platform/kick/sidecar_proxy_test.go
+package kick
+
+import "testing"
+
+func TestSidecarChromeArgs_IncludeProxy(t *testing.T) {
+	args := chromeArgsForSidecar("socks5://127.0.0.1:1080") // helper introduced in Step 3
+	found := false
+	for _, a := range args {
+		if a == "--proxy-server=socks5://127.0.0.1:1080" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected --proxy-server in chrome args, got %v", args)
+	}
+}
+
+func TestSidecarChromeArgs_NoProxyWhenEmpty(t *testing.T) {
+	for _, a := range chromeArgsForSidecar("") {
+		if len(a) >= 15 && a[:15] == "--proxy-server=" {
+			t.Fatalf("did not expect a proxy arg, got %v", a)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/platform/kick/ -run TestSidecarChromeArgs -v`
+Expected: FAIL — `chromeArgsForSidecar` undefined.
+
+- [ ] **Step 3: Implement**
+
+Read the current sidecar create code (where the Chrome container `Cmd`/args are assembled — search `--` flags or `ContainerCreate` in `internal/platform/kick/` and `internal/dockerctl/`). Extract a small helper:
+```go
+func chromeArgsForSidecar(proxyURL string) []string {
+	args := []string{ /* existing base chrome flags copied verbatim from the current create path */ }
+	if proxyURL != "" {
+		args = append(args, "--proxy-server="+proxyURL)
+	}
+	return args
+}
+```
+Wire the backend's `options.proxyURL` into this helper at container-create time.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/platform/kick/ -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/platform/kick/
+git add internal/platform/kick/
+git commit -m "feat(kick): pass --proxy-server to auto-created sidecar Chrome"
+```
+
+---
+
+### Task 6: Wire the effective proxy URL in `main.go`
+
+**Files:**
+- Modify: `cmd/miner/main.go`
+
+**Interfaces:**
+- Consumes: `kick.WithProxy`, the twitch backend proxy param (Task 4), `notify.NewDiscordWebhookWithTransport`.
+
+- [ ] **Step 1: Add `WithProxy` to the Kick options**
+
+At `main.go` where `kickOpts` is built (near line 177), add (proxy already computed as `proxyURL`, gated by `proxyEnabled`):
+```go
+	effectiveProxy := ""
+	if proxyEnabled && proxyURL != "" {
+		effectiveProxy = proxyURL
+	}
+	kickOpts = append(kickOpts, kick.WithProxy(effectiveProxy))
+```
+
+- [ ] **Step 2: Per-account Twitch backends use the proxy**
+
+At `main.go:315` (`bk := twitch.New()`) and the global backend (line 209), route through the proxy. Replace bare `twitch.New()` with the proxy-aware constructor (Task 4's signature — pass `effectiveProxy` / `proxyTransport`). Confirm both the global (209) and per-account (315) paths carry it.
+
+- [ ] **Step 3: Discord fallback always proxied**
+
+The else branch at `main.go:259` already falls back to a non-proxied webhook when `proxyTransport == nil`. That is correct (nil = proxy disabled). Verify no change needed; if `proxyTransport` is non-nil the `if` branch already applies. No edit unless a bug is found.
+
+- [ ] **Step 4: Build + full test**
+
+Run: `go build ./... && go test ./...`
+Expected: build OK, all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w cmd/miner/
+git add cmd/miner/main.go
+git commit -m "feat(miner): thread the global proxy into Kick, Twitch, and sidecars"
+```
+
+---
+
+### Task 7: Changelog + verification gate
+
+**Files:**
+- Modify: `docs/CHANGELOG.md`
+
+- [ ] **Step 1: Log under `[Unreleased]`**
+
+```markdown
+### Fixed
+
+- **All outbound traffic now honours the proxy.** Kick's Chrome-fingerprinted
+  HTTP and WebSocket paths, Twitch PubSub, per-account Twitch, Discord webhooks,
+  and the Kick browser sidecar previously bypassed the configured proxy. They
+  now tunnel through it (SOCKS5 or HTTP CONNECT) with the TLS fingerprint
+  unchanged. Restart to apply.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/CHANGELOG.md
+git commit -m "docs(changelog): all outbound traffic honours the proxy"
+```
+
+- [ ] **Step 3: Live verification gate (accrual-touching — required before tagging)**
+
+This changes the Kick watch/accrual network path. Per repo rules, before any
+version tag:
+1. Deploy to staging (local-build recipe) with a real proxy configured + enabled.
+2. Confirm Kick still passes Cloudflare (drops catalog loads, no 403) — proves
+   the utls fingerprint survived the tunnel.
+3. Confirm Kick accrual still accrues through the proxy on a live drop (or the
+   Heartbeat/accrual canary is green through the proxy).
+4. Confirm the proxy-test endpoint reports the proxy IP, and (optionally) that
+   the target host sees the proxy IP, not the host IP.
+Hold the tag in `[Unreleased]` until a live Kick check passes.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** primitive (T1), Kick HTTP (T2), Kick WS (T3), Twitch PubSub + per-account (T4), sidecar (T5), main wiring + Discord (T6), changelog + accrual gate (T7). All spec components covered; per-account Twitch (`main.go:315`) added beyond the spec as an additional bypass found during planning.
+- **Placeholders:** none — the only "read the current code" notes are for the PubSub constructor name and the sidecar base Chrome flags, which must be copied verbatim from existing code; test + wiring code is complete.
+- **Type consistency:** `netutil.DialContextFunc` and `netutil.ProxyDialer` used consistently across T1–T6; `WithProxy(string) Option`, `newHTTPDoer(DialContextFunc)`, `wsProxyDial` var, `PubSubClient.dial` field all match their definitions.

--- a/internal/auth/browser/sidecar/browser.go
+++ b/internal/auth/browser/sidecar/browser.go
@@ -109,6 +109,12 @@ func New(ctx context.Context) *Browser {
 	if bin := os.Getenv("CHROME_BIN"); bin != "" {
 		opts = append(opts, chromedp.ExecPath(bin))
 	}
+
+	// When the miner's global proxy is configured, GRUB_SIDECAR_PROXY is set
+	// on this container's env so Chrome's own egress routes through it too
+	// (see internal/platform/kick/sidecars.go sidecarEnv).
+	opts = append(opts, proxyAllocOpts(os.Getenv("GRUB_SIDECAR_PROXY"))...)
+
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
 	return &Browser{
 		allocCtx:    allocCtx,
@@ -117,6 +123,15 @@ func New(ctx context.Context) *Browser {
 		baseOpts:    opts,
 		tabs:        map[string]tabState{},
 	}
+}
+
+// proxyAllocOpts returns a chromedp option enabling Chrome's proxy when
+// proxyURL is non-empty, else nothing. Chrome accepts http/https/socks5.
+func proxyAllocOpts(proxyURL string) []chromedp.ExecAllocatorOption {
+	if proxyURL == "" {
+		return nil
+	}
+	return []chromedp.ExecAllocatorOption{chromedp.Flag("proxy-server", proxyURL)}
 }
 
 // StealthScript is the JS payload evaluated on every new document

--- a/internal/auth/browser/sidecar/browser_proxy_test.go
+++ b/internal/auth/browser/sidecar/browser_proxy_test.go
@@ -1,0 +1,15 @@
+package sidecar
+
+import "testing"
+
+func TestProxyAllocOpts_EmptyIsNil(t *testing.T) {
+	if got := proxyAllocOpts(""); got != nil {
+		t.Fatalf("expected nil for empty proxy, got %d opts", len(got))
+	}
+}
+
+func TestProxyAllocOpts_SetReturnsOne(t *testing.T) {
+	if got := proxyAllocOpts("socks5://127.0.0.1:1080"); len(got) != 1 {
+		t.Fatalf("expected 1 opt for a configured proxy, got %d", len(got))
+	}
+}

--- a/internal/dockerctl/dockerctl.go
+++ b/internal/dockerctl/dockerctl.go
@@ -34,6 +34,7 @@ type CreateSpec struct {
 	Port     int               // gRPC port to expose (no host binding)
 	Networks []string          // user-defined networks to attach to
 	Labels   map[string]string // managed/account/slug labels
+	Env      []string          // container environment ("KEY=VALUE" entries)
 }
 
 // ContainerInfo is the slice of a listed container the sweep needs.
@@ -166,6 +167,7 @@ func (s *sdkEngine) create(ctx context.Context, spec CreateSpec) error {
 	cfg := &container.Config{
 		Image:        spec.Image,
 		Labels:       spec.Labels,
+		Env:          spec.Env,
 		ExposedPorts: nat.PortSet{port: struct{}{}},
 	}
 	// RestartPolicy intentionally empty ("no"): the miner owns the lifecycle

--- a/internal/netutil/dialer.go
+++ b/internal/netutil/dialer.go
@@ -1,0 +1,93 @@
+// internal/netutil/dialer.go
+package netutil
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// DialContextFunc dials a TCP connection to addr, optionally tunneled through a
+// proxy. The returned conn speaks directly to the target host, so callers layer
+// utls/TLS/HTTP on top exactly as they would for a direct connection.
+type DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// ProxyDialer returns a dialer for proxyURL. Empty → direct. socks5:// →
+// golang.org/x/net/proxy. http(s):// → HTTP CONNECT tunnel. Unsupported schemes
+// return an error so startup can surface a misconfiguration.
+func ProxyDialer(proxyURL string) (DialContextFunc, error) {
+	base := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	if proxyURL == "" {
+		return base.DialContext, nil
+	}
+	parsed, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse proxy url: %w", err)
+	}
+	switch parsed.Scheme {
+	case "socks5":
+		return func(ctx context.Context, network, addr string) (net.Conn, error) {
+			d, err := proxy.SOCKS5("tcp", parsed.Host, nil, base)
+			if err != nil {
+				return nil, fmt.Errorf("socks5 dialer: %w", err)
+			}
+			if cd, ok := d.(proxy.ContextDialer); ok {
+				return cd.DialContext(ctx, network, addr)
+			}
+			// Fallback: run blocking Dial with ctx cancellation.
+			type res struct {
+				c net.Conn
+				e error
+			}
+			ch := make(chan res, 1)
+			go func() { c, e := d.Dial(network, addr); ch <- res{c, e} }()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case r := <-ch:
+				return r.c, r.e
+			}
+		}, nil
+	case "http", "https":
+		return func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := base.DialContext(ctx, "tcp", parsed.Host)
+			if err != nil {
+				return nil, fmt.Errorf("dial proxy: %w", err)
+			}
+			req := &http.Request{
+				Method: http.MethodConnect,
+				URL:    &url.URL{Opaque: addr},
+				Host:   addr,
+				Header: make(http.Header),
+			}
+			if parsed.User != nil {
+				if pw, ok := parsed.User.Password(); ok {
+					req.SetBasicAuth(parsed.User.Username(), pw)
+				}
+			}
+			if err := req.Write(conn); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("write CONNECT: %w", err)
+			}
+			br := bufio.NewReader(conn)
+			resp, err := http.ReadResponse(br, req)
+			if err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("read CONNECT response: %w", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				conn.Close()
+				return nil, fmt.Errorf("proxy CONNECT failed: %s", resp.Status)
+			}
+			return conn, nil
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported proxy scheme %q", parsed.Scheme)
+	}
+}

--- a/internal/netutil/dialer.go
+++ b/internal/netutil/dialer.go
@@ -4,6 +4,7 @@ package netutil
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/http"
@@ -68,7 +69,8 @@ func ProxyDialer(proxyURL string) (DialContextFunc, error) {
 			}
 			if parsed.User != nil {
 				if pw, ok := parsed.User.Password(); ok {
-					req.SetBasicAuth(parsed.User.Username(), pw)
+					auth := base64.StdEncoding.EncodeToString([]byte(parsed.User.Username() + ":" + pw))
+					req.Header.Set("Proxy-Authorization", "Basic "+auth)
 				}
 			}
 			if err := req.Write(conn); err != nil {

--- a/internal/netutil/dialer_test.go
+++ b/internal/netutil/dialer_test.go
@@ -4,6 +4,7 @@ package netutil
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"io"
 	"net"
 	"net/http"
@@ -74,6 +75,48 @@ func httpConnectProxy(t *testing.T) (addr string, connects func() int) {
 	return ln.Addr().String(), func() int { return n }
 }
 
+// httpConnectProxyWithAuth starts an HTTP CONNECT proxy that validates
+// Proxy-Authorization header and records the captured request. Returns proxy
+// addr + a func to retrieve the captured CONNECT request.
+func httpConnectProxyWithAuth(t *testing.T) (addr string, getCaptured func() *http.Request) {
+	t.Helper()
+	var captured *http.Request
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			client, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				br := bufio.NewReader(client)
+				req, err := http.ReadRequest(br)
+				if err != nil || req.Method != http.MethodConnect {
+					client.Close()
+					return
+				}
+				captured = req
+				target, err := net.Dial("tcp", req.Host)
+				if err != nil {
+					client.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+					client.Close()
+					return
+				}
+				client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+				go io.Copy(target, br)
+				io.Copy(client, target)
+				client.Close()
+				target.Close()
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() *http.Request { return captured }
+}
+
 func readAll(t *testing.T, c net.Conn) string {
 	t.Helper()
 	c.SetReadDeadline(time.Now().Add(2 * time.Second))
@@ -130,4 +173,53 @@ func TestProxyDialer_SOCKS5(t *testing.T) {
 	if _, err := ProxyDialer("socks5://127.0.0.1:1080"); err != nil {
 		t.Fatalf("socks5 construction should succeed: %v", err)
 	}
+}
+
+func TestProxyDialer_AuthenticatedHTTPConnectUsesProxyAuthorizationHeader(t *testing.T) {
+	target := echoServer(t)
+	proxyAddr, getCaptured := httpConnectProxyWithAuth(t)
+	dial, err := ProxyDialer("http://user:pass@" + proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := dial(context.Background(), "tcp", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if got := readAll(t, c); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+	req := getCaptured()
+	if req == nil {
+		t.Fatal("proxy did not capture CONNECT request")
+	}
+	// Verify Proxy-Authorization header is set and Authorization is not.
+	proxyAuth := req.Header.Get("Proxy-Authorization")
+	auth := req.Header.Get("Authorization")
+	if proxyAuth == "" {
+		t.Fatal("Proxy-Authorization header missing")
+	}
+	if auth != "" {
+		t.Fatalf("Authorization header should not be set, but got %q", auth)
+	}
+	if !validProxyBasicAuth(proxyAuth, "user", "pass") {
+		t.Fatalf("Proxy-Authorization header invalid: %q", proxyAuth)
+	}
+}
+
+// validProxyBasicAuth checks if the Proxy-Authorization header is a valid Basic
+// auth for the given username and password.
+func validProxyBasicAuth(header, user, pass string) bool {
+	if len(header) < len("Basic ") || header[:6] != "Basic " {
+		return false
+	}
+	// Verify the base64 part encodes user:pass.
+	expectedEncoded := base64EncodeString(user + ":" + pass)
+	return header[6:] == expectedEncoded
+}
+
+// base64EncodeString is a helper to base64-encode a string.
+func base64EncodeString(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
 }

--- a/internal/netutil/dialer_test.go
+++ b/internal/netutil/dialer_test.go
@@ -1,0 +1,133 @@
+// internal/netutil/dialer_test.go
+package netutil
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// echoServer starts a TCP server that writes "hello" to any client and returns its addr.
+func echoServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_, _ = c.Write([]byte("hello"))
+			c.Close()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// httpConnectProxy starts a minimal HTTP CONNECT proxy that tunnels to the
+// requested target and records that it was used. Returns proxy addr + a func
+// reporting how many CONNECTs it served.
+func httpConnectProxy(t *testing.T) (addr string, connects func() int) {
+	t.Helper()
+	var n int
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			client, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				br := bufio.NewReader(client)
+				req, err := http.ReadRequest(br)
+				if err != nil || req.Method != http.MethodConnect {
+					client.Close()
+					return
+				}
+				n++
+				target, err := net.Dial("tcp", req.Host)
+				if err != nil {
+					client.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+					client.Close()
+					return
+				}
+				client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+				go io.Copy(target, br)
+				io.Copy(client, target)
+				client.Close()
+				target.Close()
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() int { return n }
+}
+
+func readAll(t *testing.T, c net.Conn) string {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	b, _ := io.ReadAll(c)
+	return string(b)
+}
+
+func TestProxyDialer_DirectWhenEmpty(t *testing.T) {
+	target := echoServer(t)
+	dial, err := ProxyDialer("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := dial(context.Background(), "tcp", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if got := readAll(t, c); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestProxyDialer_HTTPConnectTunnel(t *testing.T) {
+	target := echoServer(t)
+	proxyAddr, connects := httpConnectProxy(t)
+	dial, err := ProxyDialer("http://" + proxyAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := dial(context.Background(), "tcp", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if got := readAll(t, c); got != "hello" {
+		t.Fatalf("got %q", got)
+	}
+	if connects() == 0 {
+		t.Fatal("proxy was not used — traffic bypassed it")
+	}
+}
+
+func TestProxyDialer_UnsupportedScheme(t *testing.T) {
+	if _, err := ProxyDialer("ftp://nope:1"); err == nil {
+		t.Fatal("expected error for unsupported scheme")
+	}
+}
+
+func TestProxyDialer_SOCKS5(t *testing.T) {
+	// Uses a tiny in-test SOCKS5 server is heavy; instead assert construction
+	// succeeds for a socks5 URL (dial exercised in staging). A bad host still
+	// constructs — dial-time failure is the fail-loud path.
+	if _, err := ProxyDialer("socks5://127.0.0.1:1080"); err != nil {
+		t.Fatalf("socks5 construction should succeed: %v", err)
+	}
+}

--- a/internal/notify/discord.go
+++ b/internal/notify/discord.go
@@ -34,10 +34,19 @@ func NewDiscordWebhook(url string, filter *VerbosityFilter) *DiscordWebhook {
 }
 
 func NewDiscordWebhookWithTransport(url string, filter *VerbosityFilter, transport *http.Transport) *DiscordWebhook {
+	client := &http.Client{Timeout: 10 * time.Second}
+	// A nil *http.Transport assigned into http.Client.Transport (an
+	// interface) is a non-nil interface wrapping a nil pointer, which
+	// panics on first use. Only set Transport when non-nil so the
+	// zero-value case behaves exactly like NewDiscordWebhook (client uses
+	// http.DefaultTransport, i.e. direct).
+	if transport != nil {
+		client.Transport = transport
+	}
 	return &DiscordWebhook{
 		URL:    url,
 		Filter: filter,
-		HTTP:   &http.Client{Timeout: 10 * time.Second, Transport: transport},
+		HTTP:   client,
 	}
 }
 

--- a/internal/notify/router.go
+++ b/internal/notify/router.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"net/http"
 	"sync"
 )
 
@@ -13,9 +14,10 @@ type AccountURLResolver func(accountID string) string
 // and routes to a per-account Discord webhook when one is configured.
 // Otherwise it delegates to the fallback notifier.
 type AccountRoutedNotifier struct {
-	fallback Notifier
-	resolve  AccountURLResolver
-	filter   *VerbosityFilter
+	fallback  Notifier
+	resolve   AccountURLResolver
+	filter    *VerbosityFilter
+	transport *http.Transport
 
 	// Branding applied to each per-account webhook client.
 	Username  string
@@ -25,12 +27,13 @@ type AccountRoutedNotifier struct {
 	cache map[string]*DiscordWebhook
 }
 
-func NewAccountRouted(fallback Notifier, resolve AccountURLResolver, filter *VerbosityFilter) *AccountRoutedNotifier {
+func NewAccountRouted(fallback Notifier, resolve AccountURLResolver, filter *VerbosityFilter, transport *http.Transport) *AccountRoutedNotifier {
 	return &AccountRoutedNotifier{
-		fallback: fallback,
-		resolve:  resolve,
-		filter:   filter,
-		cache:    map[string]*DiscordWebhook{},
+		fallback:  fallback,
+		resolve:   resolve,
+		filter:    filter,
+		transport: transport,
+		cache:     map[string]*DiscordWebhook{},
 	}
 }
 
@@ -53,7 +56,7 @@ func (r *AccountRoutedNotifier) client(url string) *DiscordWebhook {
 	if wh, ok := r.cache[url]; ok {
 		return wh
 	}
-	wh := NewDiscordWebhook(url, r.filter)
+	wh := NewDiscordWebhookWithTransport(url, r.filter, r.transport)
 	wh.Username = r.Username
 	wh.AvatarURL = r.AvatarURL
 	r.cache[url] = wh

--- a/internal/notify/router_test.go
+++ b/internal/notify/router_test.go
@@ -41,7 +41,7 @@ func TestRouter_RoutesToPerAccountURL(t *testing.T) {
 			return srv.URL
 		}
 		return ""
-	}, nil)
+	}, nil, nil)
 
 	require.NoError(t, r.Notify(context.Background(), EventClaim, map[string]any{
 		"account": "acc1", "benefit": "b1",
@@ -62,7 +62,7 @@ func TestRouter_PropagatesBrandingToPerAccountClient(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	r := NewAccountRouted(&captureNotifier{}, func(string) string { return srv.URL }, nil)
+	r := NewAccountRouted(&captureNotifier{}, func(string) string { return srv.URL }, nil, nil)
 	r.Username = "GrubDrops"
 	r.AvatarURL = "https://img/a.png"
 
@@ -76,7 +76,7 @@ func TestRouter_PropagatesBrandingToPerAccountClient(t *testing.T) {
 
 func TestRouter_FallsBackWhenNoAccountURL(t *testing.T) {
 	fallback := &captureNotifier{}
-	r := NewAccountRouted(fallback, func(_ string) string { return "" }, nil)
+	r := NewAccountRouted(fallback, func(_ string) string { return "" }, nil, nil)
 
 	require.NoError(t, r.Notify(context.Background(), EventState, map[string]any{
 		"account": "acc1", "state": "watching",
@@ -84,9 +84,19 @@ func TestRouter_FallsBackWhenNoAccountURL(t *testing.T) {
 	assert.Len(t, fallback.events, 1)
 }
 
+func TestRouter_ClientUsesConfiguredTransport(t *testing.T) {
+	transport := &http.Transport{}
+	r := NewAccountRouted(&captureNotifier{}, func(string) string { return "http://example.invalid/webhook" }, nil, transport)
+
+	wh := r.client("http://example.invalid/webhook")
+
+	require.NotNil(t, wh.HTTP)
+	assert.Same(t, transport, wh.HTTP.Transport)
+}
+
 func TestRouter_FallsBackWhenAccountFieldMissing(t *testing.T) {
 	fallback := &captureNotifier{}
-	r := NewAccountRouted(fallback, func(_ string) string { return "http://should-not-be-used" }, nil)
+	r := NewAccountRouted(fallback, func(_ string) string { return "http://should-not-be-used" }, nil, nil)
 
 	require.NoError(t, r.Notify(context.Background(), EventError, map[string]any{
 		"panic": "oh no",

--- a/internal/platform/kick/api.go
+++ b/internal/platform/kick/api.go
@@ -51,7 +51,7 @@ type api struct {
 	d doer
 }
 
-func newAPI() *api { return &api{d: newHTTPDoer()} }
+func newAPI() *api { return &api{d: newHTTPDoer(nil)} }
 
 // ---- Public channel discovery (no auth required) -------------------------
 

--- a/internal/platform/kick/backend.go
+++ b/internal/platform/kick/backend.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aalejandrofer/grubdrops/internal/auth/browser"
 	"github.com/aalejandrofer/grubdrops/internal/dockerctl"
+	"github.com/aalejandrofer/grubdrops/internal/netutil"
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
@@ -71,6 +72,7 @@ type Option func(*options)
 type options struct {
 	sidecarImage   string
 	sidecarNetwork string
+	proxyURL       string
 }
 
 // WithSidecarAutoCreate enables auto-create of per-account browser sidecars:
@@ -80,6 +82,10 @@ type options struct {
 func WithSidecarAutoCreate(image, network string) Option {
 	return func(o *options) { o.sidecarImage, o.sidecarNetwork = image, network }
 }
+
+// WithProxy routes the utls HTTP transport (drops API, discovery, claim)
+// through proxyURL. Empty string keeps the direct dialer.
+func WithProxy(proxyURL string) Option { return func(o *options) { o.proxyURL = proxyURL } }
 
 // New builds the Kick backend. c is the login client (data flows over the utls
 // HTTP client; c is kept for the interactive-login path). ctl controls the
@@ -96,9 +102,14 @@ func New(c *browser.Client, ctl dockerctl.Controller, template string, port int,
 	if o.sidecarImage != "" {
 		reg.withCreate(o.sidecarImage, o.sidecarNetwork)
 	}
+	dial, err := netutil.ProxyDialer(o.proxyURL)
+	if err != nil {
+		slog.Warn("kick: bad proxy url, using direct", "err", err)
+		dial = nil
+	}
 	b := &Backend{
 		c:                c,
-		api:              newAPI(),
+		api:              &api{d: newHTTPDoer(dial)},
 		sidecars:         reg,
 		clientByName:     map[string]*browser.Client{},
 		sidecarPort:      port,

--- a/internal/platform/kick/backend.go
+++ b/internal/platform/kick/backend.go
@@ -107,6 +107,7 @@ func New(c *browser.Client, ctl dockerctl.Controller, template string, port int,
 		slog.Warn("kick: bad proxy url, using direct", "err", err)
 		dial = nil
 	}
+	wsProxyDial = dial
 	b := &Backend{
 		c:                c,
 		api:              &api{d: newHTTPDoer(dial)},

--- a/internal/platform/kick/backend.go
+++ b/internal/platform/kick/backend.go
@@ -102,6 +102,7 @@ func New(c *browser.Client, ctl dockerctl.Controller, template string, port int,
 	if o.sidecarImage != "" {
 		reg.withCreate(o.sidecarImage, o.sidecarNetwork)
 	}
+	reg.withProxy(o.proxyURL)
 	dial, err := netutil.ProxyDialer(o.proxyURL)
 	if err != nil {
 		slog.Warn("kick: bad proxy url, using direct", "err", err)

--- a/internal/platform/kick/probe.go
+++ b/internal/platform/kick/probe.go
@@ -15,7 +15,7 @@ import (
 // the safe way to confirm the endpoint exists + the body parses without
 // changing inventory). One-shot ops tool.
 func ProbeClaim(ctx context.Context, sess platform.Session, rewardID, campaignID string) {
-	d := newHTTPDoer()
+	d := newHTTPDoer(nil)
 	payload := []byte(fmt.Sprintf(`{"reward_id":%q,"campaign_id":%q}`, rewardID, campaignID))
 	fmt.Printf("POST %s/api/v1/drops/claim  body=%s\n", dropsBase, payload)
 	body, status, err := d.do(ctx, sess, http.MethodPost, dropsBase+"/api/v1/drops/claim", payload)
@@ -33,7 +33,7 @@ func ProbeClaim(ctx context.Context, sess platform.Session, rewardID, campaignID
 // apart from "empty 200". Wired only into cmd/kick-probe; not used by the
 // daemon. Output goes to stdout.
 func Probe(ctx context.Context, sess platform.Session, categorySlug string) {
-	d := newHTTPDoer()
+	d := newHTTPDoer(nil)
 	a := newAPI()
 
 	dump := func(label, base, path string) {

--- a/internal/platform/kick/sidecars.go
+++ b/internal/platform/kick/sidecars.go
@@ -56,6 +56,10 @@ type sidecarRegistry struct {
 	image string
 	// netOverride forces the sidecar network; "" means self-detect once.
 	netOverride string
+	// proxyURL, when set, is passed to auto-created sidecars via
+	// GRUB_SIDECAR_PROXY so their Chrome egresses through the same proxy as
+	// the rest of the Kick backend's traffic.
+	proxyURL string
 
 	// netOnce guards lazy network self-detection (inspect the miner's own
 	// container) so we only inspect once and cache the result.
@@ -76,6 +80,23 @@ func (r *sidecarRegistry) withCreate(image, netOverride string) *sidecarRegistry
 	r.image = image
 	r.netOverride = netOverride
 	return r
+}
+
+// withProxy sets the proxy URL (may be "") passed to auto-created sidecars via
+// GRUB_SIDECAR_PROXY. Returns r for chaining at construction.
+func (r *sidecarRegistry) withProxy(proxyURL string) *sidecarRegistry {
+	r.proxyURL = proxyURL
+	return r
+}
+
+// sidecarEnv builds the env for an auto-created sidecar. When a proxy is
+// configured, GRUB_SIDECAR_PROXY tells the sidecar's Chrome to route
+// through it (see internal/auth/browser/sidecar).
+func sidecarEnv(proxyURL string) []string {
+	if proxyURL == "" {
+		return nil
+	}
+	return []string{"GRUB_SIDECAR_PROXY=" + proxyURL}
 }
 
 // register derives the account's sidecar from its username. Safe to call again
@@ -227,6 +248,7 @@ func (r *sidecarRegistry) ensureUp(ctx context.Context, accountID string, ready 
 				dockerctl.LabelAccount: accountID,
 				dockerctl.LabelSlug:    slug,
 			},
+			Env: sidecarEnv(r.proxyURL),
 		}); err != nil {
 			return err
 		}

--- a/internal/platform/kick/sidecars_env_test.go
+++ b/internal/platform/kick/sidecars_env_test.go
@@ -1,0 +1,13 @@
+package kick
+
+import "testing"
+
+func TestSidecarEnv(t *testing.T) {
+	if sidecarEnv("") != nil {
+		t.Fatal("expected nil env when no proxy")
+	}
+	env := sidecarEnv("http://p:8080")
+	if len(env) != 1 || env[0] != "GRUB_SIDECAR_PROXY=http://p:8080" {
+		t.Fatalf("got %v", env)
+	}
+}

--- a/internal/platform/kick/transport.go
+++ b/internal/platform/kick/transport.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aalejandrofer/grubdrops/internal/netutil"
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/http2"
@@ -39,6 +40,7 @@ type httpDoer struct {
 	timeout time.Duration
 	mu      sync.Mutex
 	conns   map[string]*cachedConn // host -> cached connection
+	dial    netutil.DialContextFunc
 }
 
 type cachedConn struct {
@@ -48,10 +50,18 @@ type cachedConn struct {
 	lastUse time.Time
 }
 
-func newHTTPDoer() *httpDoer {
+// newHTTPDoer builds an httpDoer that dials new connections through dial. A
+// nil dial (the common case, and every existing call site) falls back to a
+// direct net.Dialer, matching the prior behaviour.
+func newHTTPDoer(dial netutil.DialContextFunc) *httpDoer {
+	if dial == nil {
+		var nd net.Dialer
+		dial = nd.DialContext
+	}
 	return &httpDoer{
 		timeout: 20 * time.Second,
 		conns:   map[string]*cachedConn{},
+		dial:    dial,
 	}
 }
 
@@ -67,8 +77,7 @@ func (d *httpDoer) connFor(ctx context.Context, host string) (*cachedConn, error
 
 	dialCtx, cancel := context.WithTimeout(ctx, d.timeout)
 	defer cancel()
-	var dialer net.Dialer
-	tcp, err := dialer.DialContext(dialCtx, "tcp", host+":443")
+	tcp, err := d.dial(dialCtx, "tcp", host+":443")
 	if err != nil {
 		return nil, fmt.Errorf("dial: %w", err)
 	}

--- a/internal/platform/kick/transport_test.go
+++ b/internal/platform/kick/transport_test.go
@@ -19,3 +19,17 @@ func TestHTTPDoer_UsesInjectedDialer(t *testing.T) {
 		t.Fatal("httpDoer did not use the injected dialer")
 	}
 }
+
+func TestNewUTLSConn_UsesProxyDial(t *testing.T) {
+	var used int32
+	old := wsProxyDial
+	t.Cleanup(func() { wsProxyDial = old })
+	wsProxyDial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&used, 1)
+		return nil, context.Canceled
+	}
+	_, _ = newUTLSConn(context.Background(), "tcp", "web.kick.com:443")
+	if atomic.LoadInt32(&used) == 0 {
+		t.Fatal("newUTLSConn did not use wsProxyDial")
+	}
+}

--- a/internal/platform/kick/transport_test.go
+++ b/internal/platform/kick/transport_test.go
@@ -1,0 +1,21 @@
+package kick
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+func TestHTTPDoer_UsesInjectedDialer(t *testing.T) {
+	var used int32
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&used, 1)
+		return nil, context.Canceled // short-circuit; we only assert it was called
+	}
+	d := newHTTPDoer(dial)
+	_, _ = d.connFor(context.Background(), "web.kick.com")
+	if atomic.LoadInt32(&used) == 0 {
+		t.Fatal("httpDoer did not use the injected dialer")
+	}
+}

--- a/internal/platform/kick/wswatch.go
+++ b/internal/platform/kick/wswatch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/websocket"
 	utls "github.com/refraction-networking/utls"
 
+	"github.com/aalejandrofer/grubdrops/internal/netutil"
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
@@ -71,8 +72,12 @@ func wsUserEvent(channelID, livestreamID int64) map[string]any {
 // forcing http/1.1 ALPN (the WebSocket upgrade is http/1.1, and the token host
 // is happy on 1.1). Mirrors the verified kickautodrops client.
 func newUTLSConn(ctx context.Context, network, addr string) (net.Conn, error) {
-	d := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
-	raw, err := d.DialContext(ctx, network, addr)
+	dial := wsProxyDial
+	if dial == nil {
+		d := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+		dial = d.DialContext
+	}
+	raw, err := dial(ctx, network, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +117,10 @@ func newUTLSConn(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 	return uc, nil
 }
+
+// wsProxyDial is the TCP dialer for the WS utls path, set once at backend
+// construction (WithProxy). Nil means direct.
+var wsProxyDial netutil.DialContextFunc
 
 var (
 	wsHTTPClient = &http.Client{

--- a/internal/platform/twitch/backend.go
+++ b/internal/platform/twitch/backend.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/aalejandrofer/grubdrops/internal/gameslug"
+	"github.com/aalejandrofer/grubdrops/internal/netutil"
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
@@ -102,8 +103,9 @@ type Backend struct {
 	pubsub         *PubSubClient
 	pubsubCancel   context.CancelFunc
 	pubsubHandlers PubSubHandlers
-	pubsubDisabled bool   // tests disable via newForTest
-	boundAccount   string // first account to bind hooks; guards single-account use
+	pubsubDial     netutil.DialContextFunc // routes the PubSub WS dial through the proxy, if any
+	pubsubDisabled bool                    // tests disable via newForTest
+	boundAccount   string                  // first account to bind hooks; guards single-account use
 }
 
 var _ platform.Backend = (*Backend)(nil)
@@ -156,6 +158,22 @@ func NewWithTransport(transport *http.Transport) *Backend {
 		adv:                     &advisory{c: c},
 		allowedLoginsByCampaign: map[string][]string{},
 	}
+}
+
+// NewWithProxy creates a Backend whose HTTP traffic uses transport (as
+// NewWithTransport does) and whose PubSub WebSocket dials through proxyURL
+// (via netutil.ProxyDialer), so per-account backends fully honor the global
+// proxy rather than just their HTTP calls. proxyURL == "" dials direct,
+// matching NewWithTransport's behavior for the WS leg too. Wired up by the
+// caller (cmd/miner/main.go) in a later task.
+func NewWithProxy(transport *http.Transport, proxyURL string) (*Backend, error) {
+	dial, err := netutil.ProxyDialer(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("twitch: build proxy dialer: %w", err)
+	}
+	b := NewWithTransport(transport)
+	b.pubsubDial = dial
+	return b, nil
 }
 
 // newForTest builds a Backend pointed at a test endpoint. Used by tests
@@ -285,7 +303,7 @@ func (b *Backend) ensurePubSub(s platform.Session) {
 		return
 	}
 	handlers := b.pubsubHandlers
-	client := NewPubSubClient(s.AccessToken, handlers)
+	client := NewPubSubClientWithDial(s.AccessToken, handlers, b.pubsubDial)
 	ctx, cancel := context.WithCancel(context.Background())
 	b.pubsub = client
 	b.pubsubCancel = cancel

--- a/internal/platform/twitch/pubsub.go
+++ b/internal/platform/twitch/pubsub.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aalejandrofer/grubdrops/internal/netutil"
 	"github.com/gorilla/websocket"
 )
 
@@ -67,6 +68,7 @@ type PubSubHandlers struct {
 type PubSubClient struct {
 	authToken string
 	handlers  PubSubHandlers
+	dial      netutil.DialContextFunc // optional; routes the WS dial through a proxy
 
 	mu      sync.Mutex
 	topics  map[string]struct{}
@@ -78,11 +80,27 @@ type PubSubClient struct {
 
 // NewPubSubClient builds a client. Call Connect to dial.
 func NewPubSubClient(authToken string, handlers PubSubHandlers) *PubSubClient {
+	return NewPubSubClientWithDial(authToken, handlers, nil)
+}
+
+// NewPubSubClientWithDial builds a client whose WebSocket dial goes through
+// dial when non-nil (e.g. the output of netutil.ProxyDialer), so per-account
+// backends built with a proxy carry it through to their PubSub socket too.
+// A nil dial behaves exactly like NewPubSubClient (direct dial).
+func NewPubSubClientWithDial(authToken string, handlers PubSubHandlers, dial netutil.DialContextFunc) *PubSubClient {
 	return &PubSubClient{
 		authToken: authToken,
 		handlers:  handlers,
+		dial:      dial,
 		topics:    map[string]struct{}{},
 	}
+}
+
+// newPubSubClientWithDial is the test-facing constructor named by the task
+// brief (TestPubSub_UsesProxyDial): a bare dialer with no auth/handlers,
+// sufficient to exercise dialAndPump's dial wiring in isolation.
+func newPubSubClientWithDial(dial netutil.DialContextFunc) *PubSubClient {
+	return NewPubSubClientWithDial("", PubSubHandlers{}, dial)
 }
 
 // Close stops the Run loop and closes the WebSocket connection.
@@ -183,6 +201,9 @@ func (p *PubSubClient) RemoveTopic(topic string) {
 
 func (p *PubSubClient) dialAndPump(ctx context.Context) error {
 	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	if p.dial != nil {
+		dialer.NetDialContext = p.dial
+	}
 	conn, _, err := dialer.DialContext(ctx, PubSubEndpoint, http.Header{})
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)

--- a/internal/platform/twitch/pubsub_test.go
+++ b/internal/platform/twitch/pubsub_test.go
@@ -1,0 +1,21 @@
+package twitch
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPubSub_UsesProxyDial(t *testing.T) {
+	var used int32
+	dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		atomic.AddInt32(&used, 1)
+		return nil, context.Canceled
+	}
+	p := newPubSubClientWithDial(dial)
+	_ = p.dialAndPump(context.Background())
+	if atomic.LoadInt32(&used) == 0 {
+		t.Fatal("PubSub did not use the injected dialer")
+	}
+}


### PR DESCRIPTION
Fixes the "when using a proxy, not all traffic is routed through it" bug. Every outbound path now tunnels through the configured global proxy.

## What changed
New primitive `netutil.ProxyDialer(proxyURL)` returns a TCP-tunnel dialer (SOCKS5 via `x/net/proxy`, or HTTP `CONNECT`) that hands a raw `net.Conn` straight to the target. Callers layer utls/TLS on top **unchanged**, so Kick's Chrome TLS fingerprint (the thing that beats Cloudflare) is byte-for-byte identical to the direct path. The proxy only carries TCP, never terminates TLS.

Wired into every path that previously bypassed the proxy:
- **Kick utls HTTP** (API / discovery / image/avatar) via a new `kick.WithProxy` option
- **Kick WebSocket** (viewer-token + WS watch) via the same dialer
- **Twitch PubSub** websocket (`NetDialContext`)
- **Per-account Twitch** HTTP + PubSub (`twitch.NewWithProxy`)
- **Kick browser sidecar** Chrome — proxy passed as a container env var (`GRUB_SIDECAR_PROXY`) that the sidecar reads into a `--proxy-server` flag
- **Discord webhooks** — both the global fallback and per-account routed webhooks

Global-only, read once at startup, **restart to apply**. The dormant per-account `accounts.proxy_url` column was removed separately on master.

## Error handling
Fail-loud: if the proxy is enabled but the URL is unusable, the miner refuses to start (startup validation) rather than silently leaking traffic direct.

## Testing
- `netutil.ProxyDialer` unit tests: direct, HTTP CONNECT tunnel (incl. `Proxy-Authorization`), unsupported-scheme error.
- Per-path wiring tests assert each dialer is actually used (Kick HTTP/WS, Twitch PubSub) and that per-account Discord carries the transport.
- Full suite + `go vet` + `-race` on touched packages: green. gofmt clean.
- Built via subagent-driven TDD with per-task review + an opus whole-branch review (two findings fixed: per-account Discord leak, fail-loud).

## Release gate ⚠️
This changes the Kick watch/accrual network path, so per the repo rules it is **accrual-touching and must be live-verified against a Kick drop through a real proxy on staging before tagging** — do not tag on unit tests alone. The wiring tests assert the dialer is *called*, not that real traffic tunnels end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)