### PR TITLE
fix(twitch): send minute-watched heartbeat via Spade beacon (drops no longer progress via GQL SendEvents)

### DIFF
--- a/cmd/keygen/main.go
+++ b/cmd/keygen/main.go
@@ -1,0 +1,18 @@
+// Command keygen prints a fresh age X25519 identity for use as GRUB_MASTER_KEY.
+// Run: go run ./cmd/keygen
+package main
+
+import (
+	"fmt"
+
+	"filippo.io/age"
+)
+
+func main() {
+	id, err := age.GenerateX25519Identity()
+	if err != nil {
+		panic(err)
+	}
+	// Just the secret identity line, so it's trivial to capture into an env var.
+	fmt.Println(id.String())
+}

--- a/internal/canary/twitch.go
+++ b/internal/canary/twitch.go
@@ -19,10 +19,10 @@ type beaconProber interface {
 // TwitchProbe is a standalone canary that verifies the Twitch watch-beacon
 // transport is accepted for a given session and channel.
 //
-// IMPORTANT: a passing probe proves the beacon HTTP transport is accepted
-// (HTTP 2xx from the SendEvents mutation), NOT that watch-time was credited
-// toward a drop. Drop credit additionally requires an active campaign and a
-// valid live stream — those are not verified here.
+// IMPORTANT: a passing probe proves the Spade beacon HTTP transport is
+// accepted (HTTP 204), NOT that watch-time was credited toward a drop. Drop
+// credit additionally requires an active campaign and a valid live stream —
+// those are not verified here.
 type TwitchProbe struct {
 	backend        beaconProber
 	beaconInterval time.Duration

--- a/internal/canary/twitch_test.go
+++ b/internal/canary/twitch_test.go
@@ -13,30 +13,52 @@ import (
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
-// TestTwitchProbe_OK verifies that Run returns Result{OK: true} when both
-// beacons are accepted by the (faked) Twitch GQL endpoint.
-// The test server dispatches on operationName so the CurrentUser resolve and
-// SendEvents mutation both succeed independently.
-func TestTwitchProbe_OK(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Peek at the request body to route by operationName.
-		// Both query types POST JSON with an "operationName" field.
+// spadeTestServer builds an httptest server that serves both the channel
+// page (with an inlined spade_url) and the Spade beacon endpoint, so the
+// post-2026-07-11 watch transport can resolve the beacon URL and POST to
+// it. The CurrentUser GQL query is still routed through the same server's
+// root path (httptest dispatches by path).
+//
+// beaconResponder is invoked for each beacon POST; returning a non-204
+// status lets callers simulate failures.
+func spadeTestServer(t *testing.T, channel string, beaconResponder http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	// CurrentUser GQL resolve (root /gql-style POST lands on "/").
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			OperationName string `json:"operationName"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		switch req.OperationName {
-		case "CurrentUser":
+		if req.OperationName == "CurrentUser" {
 			_, _ = w.Write([]byte(`{"data":{"currentUser":{"id":"12345"}}}`))
-		default:
-			// SendEvents and any future mutation.
-			_, _ = w.Write([]byte(`{"data":{"sendSpadeEvents":{"statusCode":204}}}`))
+			return
 		}
-	}))
+		w.WriteHeader(http.StatusNotFound)
+	})
+	// Channel page: inline the spade_url.
+	mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>"spade_url": "` + srvBase() + `/spade"</html>`))
+	})
+	// Spade beacon endpoint.
+	mux.HandleFunc("/spade", beaconResponder)
+	srv = httptest.NewServer(mux)
+	return srv
+}
+
+// TestTwitchProbe_OK verifies that Run returns Result{OK: true} when both
+// Spade beacons are accepted (HTTP 204) by the test server.
+func TestTwitchProbe_OK(t *testing.T) {
+	const channel = "testchannel"
+	srv := spadeTestServer(t, channel, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
 	defer srv.Close()
 
 	probe := canary.NewTwitchProbeForTest(srv.URL)
-	result := probe.Run(context.Background(), platform.Session{AccessToken: "tok"}, "testchannel")
+	result := probe.Run(context.Background(), platform.Session{AccessToken: "tok"}, channel)
 
 	assert.True(t, result.OK, "expected OK=true when beacons are accepted")
 	assert.Contains(t, result.Detail, "beacon", "detail should mention beacons")
@@ -44,24 +66,16 @@ func TestTwitchProbe_OK(t *testing.T) {
 }
 
 // TestTwitchProbe_Error verifies that Run returns Result{OK: false} when the
-// beacon call returns a server error.
+// Spade beacon call returns a server error.
 func TestTwitchProbe_Error(t *testing.T) {
-	callCount := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		// First call is CurrentUser (resolveUserID).
-		if callCount == 1 {
-			_, _ = w.Write([]byte(`{"data":{"currentUser":{"id":"99999"}}}`))
-			return
-		}
-		// Subsequent calls (beacons) fail.
+	const channel = "testchannel"
+	srv := spadeTestServer(t, channel, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"errors":[{"message":"internal error"}]}`))
-	}))
+	})
 	defer srv.Close()
 
 	probe := canary.NewTwitchProbeForTest(srv.URL)
-	result := probe.Run(context.Background(), platform.Session{AccessToken: "tok"}, "testchannel")
+	result := probe.Run(context.Background(), platform.Session{AccessToken: "tok"}, channel)
 
 	assert.False(t, result.OK, "expected OK=false when beacon fails")
 	assert.Contains(t, result.Detail, "beacon", "detail should describe the beacon failure")

--- a/internal/platform/twitch/backend.go
+++ b/internal/platform/twitch/backend.go
@@ -177,9 +177,12 @@ func NewWithProxy(transport *http.Transport, proxyURL string) (*Backend, error) 
 }
 
 // newForTest builds a Backend pointed at a test endpoint. Used by tests
-// that need to drive the whole interface against an httptest server.
+// that need to drive the whole interface against an httptest server. The
+// test server also serves the channel page + Spade beacon the watch
+// transport GETs/POSTs, so homeURL is set to the same endpoint.
 func newForTest(endpoint string) *Backend {
 	c := newTestClient(endpoint)
+	c.homeURL = endpoint
 	return &Backend{
 		c:                       c,
 		auth:                    newAuthFlow(),

--- a/internal/platform/twitch/client.go
+++ b/internal/platform/twitch/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -97,9 +100,14 @@ func newTestClient(endpoint string) *client {
 
 // newBrowserClient builds a client whose gql calls go through the
 // chromedp sidecar tab keyed on accountID. Used by NewBrowserBackend.
+// homeURL is set so resolveSpadeURL can GET the channel page the same
+// way the direct client does — the Spade beacon itself is always a
+// direct net/http call (Twitch's analytics edge, not /gql), so it is
+// unaffected by the /gql integrity wall.
 func newBrowserClient(send TwitchGQLSender, accountID string) *client {
 	c := &client{
 		endpoint:    gqlEndpoint,
+		homeURL:     "https://www.twitch.tv",
 		http:        &http.Client{Timeout: 20 * time.Second},
 		deviceID:    randomHex(16),
 		sessionID:   randomHex(16),
@@ -361,4 +369,99 @@ func (c *client) directPost(ctx context.Context, token, opName string, body []by
 	defer resp.Body.Close()
 	raw, _ := io.ReadAll(resp.Body)
 	return raw, resp.StatusCode, nil
+}
+
+// spadeURLRegex matches the analytics beacon URL embedded in Twitch's
+// settings JSON as "spade_url"/"beacon_url". Same pattern the reference
+// (twitch-gql-rs api::get_spade_url) uses after the 2026-07-11 Twitch
+// change that stopped crediting GQL SendEvents heartbeats. The scheme
+// accepts http and the host allows a port so the scraper is unit-
+// testable against an httptest server; production Twitch always emits
+// https with no port.
+var spadeURLRegex = regexp.MustCompile(`"(?:beacon|spade)_?url": ?"(https?://[.\w:/-]+)"`)
+
+// settingsURLRegex locates the hashed settings.js bundle in the channel
+// page HTML, used as the fallback location for the spade_url. Twitch
+// sometimes inlines spade_url directly in the page; when it doesn't, we
+// fetch settings.<hex>.js and re-scan it.
+var settingsURLRegex = regexp.MustCompile(`src="(https?://[.\w:/]+/config/settings\.[0-9a-f]{32}\.js)"`)
+
+// resolveSpadeURL scrapes the per-channel Spade minute-watched beacon
+// URL from the channel page (and its settings.js fallback). The channel
+// page sometimes inlines spade_url directly; when it doesn't, Twitch
+// stashes it in the hashed settings bundle. We send the Android client
+// headers + OAuth token on both fetches so Twitch returns the full page
+// rather than a bot challenge.
+func (c *client) resolveSpadeURL(ctx context.Context, token, channel string) (string, error) {
+	pageURL := strings.TrimRight(c.homeURL, "/") + "/" + channel
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return "", err
+	}
+	c.setCommonHeaders(req, token)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	html, _ := io.ReadAll(resp.Body)
+
+	if m := spadeURLRegex.FindSubmatch(html); m != nil {
+		return string(m[1]), nil
+	}
+	if m := settingsURLRegex.FindSubmatch(html); m != nil {
+		settingsJS, err := c.fetchText(ctx, token, string(m[1]))
+		if err != nil {
+			return "", err
+		}
+		if m2 := spadeURLRegex.FindSubmatch(settingsJS); m2 != nil {
+			return string(m2[1]), nil
+		}
+		return "", fmt.Errorf("spade url not found in settings.js for %s", channel)
+	}
+	return "", fmt.Errorf("spade url not found on channel page for %s", channel)
+}
+
+// fetchText GETs url with the common Twitch headers and returns the
+// response body. Used to pull the hashed settings.js bundle during
+// Spade URL resolution.
+func (c *client) fetchText(ctx context.Context, token, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setCommonHeaders(req, token)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+// sendSpadeBeacon POSTs a minute-watched heartbeat to the Spade
+// analytics edge. As of the 2026-07-11 Twitch change, only this path
+// accrues drop progress — the GQL SendEvents mutation is no longer
+// credited. The body is data=<urlencoded-base64-of-json> with
+// Content-Type application/x-www-form-urlencoded (NOT the gzipped
+// twilight/GZIP_B64 GQL envelope). Twitch acknowledges with HTTP 204.
+func (c *client) sendSpadeBeacon(ctx context.Context, token, spadeURL string, events []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(events)
+	body := "data=" + url.QueryEscape(encoded)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, spadeURL, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	c.setCommonHeaders(req, token)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("spade beacon: status %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/internal/platform/twitch/client_test.go
+++ b/internal/platform/twitch/client_test.go
@@ -85,3 +85,64 @@ func TestClient_GQLQueryNonPersisted(t *testing.T) {
 	assert.Contains(t, body, `"query":"mutation FooOp { foo }"`)
 	assert.Contains(t, body, `"x":1`)
 }
+
+// TestClient_ResolveSpadeURL_Inline verifies resolveSpadeURL extracts
+// the beacon URL when Twitch inlines "spade_url" directly in the channel
+// page HTML.
+func TestClient_ResolveSpadeURL_Inline(t *testing.T) {
+	const wantURL = "https://video-edge-abc.spade.twitch.tv/spade"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/somechannel", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `<html>"spade_url": "`+wantURL+`"</html>`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.homeURL = srv.URL
+	got, err := c.resolveSpadeURL(context.Background(), "tok", "somechannel")
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, got)
+}
+
+// TestClient_ResolveSpadeURL_SettingsFallback verifies the two-step
+// path: when the channel page only carries a settings.<hex>.js bundle
+// URL (no inline spade_url), resolveSpadeURL fetches that bundle and
+// extracts the beacon URL from it.
+func TestClient_ResolveSpadeURL_SettingsFallback(t *testing.T) {
+	const wantURL = "https://video-edge-xyz.spade.twitch.tv/spade"
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fallbackchannel", func(w http.ResponseWriter, r *http.Request) {
+		// No inline spade_url — only a settings bundle reference.
+		_, _ = io.WriteString(w, `<html><script src="`+srvBase()+`/config/settings.1234567890abcdef1234567890abcdef.js"></script></html>`)
+	})
+	mux.HandleFunc("/config/settings.1234567890abcdef1234567890abcdef.js", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `window.settings = {"beacon_url": "`+wantURL+`"};`)
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.homeURL = srv.URL
+	got, err := c.resolveSpadeURL(context.Background(), "tok", "fallbackchannel")
+	require.NoError(t, err)
+	assert.Equal(t, wantURL, got)
+}
+
+// TestClient_ResolveSpadeURL_NotFound verifies resolveSpadeURL errors
+// when neither the page nor a settings bundle carries a beacon URL.
+func TestClient_ResolveSpadeURL_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/deadchannel", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `<html>no analytics here</html>`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	c.homeURL = srv.URL
+	_, err := c.resolveSpadeURL(context.Background(), "tok", "deadchannel")
+	require.Error(t, err)
+}

--- a/internal/platform/twitch/ops.go
+++ b/internal/platform/twitch/ops.go
@@ -15,11 +15,6 @@ const (
 	gqlEndpoint   = "https://gql.twitch.tv/gql"
 	deviceAuthURL = "https://id.twitch.tv/oauth2/device"
 	tokenURL      = "https://id.twitch.tv/oauth2/token"
-
-	// minuteWatchedURL is the same as gqlEndpoint: as of DevilXD@c5e6286, the heartbeat is
-	// sent as a GQL mutation (SendEvents / sendSpadeEvents) rather than to a static analytics
-	// endpoint. See docs/superpowers/notes/2026-06-04-twitch-ops-source.md for payload shape.
-	minuteWatchedURL = "https://gql.twitch.tv/gql"
 )
 
 // Operation identifies a persisted GraphQL operation.

--- a/internal/platform/twitch/probe.go
+++ b/internal/platform/twitch/probe.go
@@ -17,14 +17,14 @@ func NewForTest(endpoint string) *Backend {
 
 // ProbeBeacon is the canary entry point for the Twitch watch-beacon transport.
 //
-// It verifies that the SendEvents mutation (the minute-watched beacon) is
-// accepted by Twitch for the given session and channel — without running a
-// full watcher and without requiring a live drop campaign.
+// It verifies that the Spade minute-watched beacon is accepted by Twitch for
+// the given session and channel — without running a full watcher and without
+// requiring a live drop campaign.
 //
 // IMPORTANT: a successful probe proves the beacon HTTP transport is accepted
-// (HTTP 2xx, no gql errors), not that Twitch credited watch-time for a drop.
-// Twitch silently discards watch-time that doesn't match an active campaign or
-// a valid user_id, so transport acceptance and accrual credit are distinct.
+// (HTTP 204), not that Twitch credited watch-time for a drop. Twitch silently
+// discards watch-time that doesn't match an active campaign or a valid
+// user_id, so transport acceptance and accrual credit are distinct.
 //
 // The probe:
 //  1. Resolves the authenticated user's ID (the same call the watcher makes

--- a/internal/platform/twitch/probe_test.go
+++ b/internal/platform/twitch/probe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,70 +14,89 @@ import (
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
-// TestProbeBeacon_OK verifies that ProbeBeacon returns nil when the fake
-// transport accepts every beacon (HTTP 200 with statusCode 204 in data).
+// TestProbeBeacon_OK verifies that ProbeBeacon returns nil when the
+// Spade beacon transport accepts every heartbeat (HTTP 204). After the
+// 2026-07-11 Twitch change, the probe exercises the Spade beacon POST
+// path, so the test server must serve a channel page (with an inlined
+// spade_url) plus the beacon endpoint itself.
 func TestProbeBeacon_OK(t *testing.T) {
-	var beaconCount int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		beaconCount++
-		_, _ = w.Write([]byte(`{"data":{"sendSpadeEvents":{"statusCode":204}}}`))
-	}))
+	const channel = "testchannel"
+	var beaconCount int32
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	// Channel page: inline the spade_url so resolveSpadeURL finds it.
+	mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>"spade_url": "` + srvBase() + `/spade"</html>`))
+	})
+	// Spade beacon endpoint: 204 No Content is the success signal.
+	mux.HandleFunc("/spade", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&beaconCount, 1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv = httptest.NewServer(mux)
 	defer srv.Close()
 
 	b := newForTest(srv.URL)
-	// Pre-populate cachedUserID to skip the CurrentUser fetch (same pattern
-	// used by TestWatch_HeartbeatSendsAuthHeader), so the test server only
-	// needs to handle the SendEvents mutation.
+	// Pre-populate cachedUserID to skip the CurrentUser fetch, so the
+	// test server only needs to handle the channel page + beacon.
 	b.watch.cachedUserID = 12345
 	sess := platform.Session{AccessToken: "tok-probe"}
 	// Use 0 interval so the test doesn't wait 60s between beacons.
-	err := b.ProbeBeacon(context.Background(), sess, "testchannel", 0)
+	err := b.ProbeBeacon(context.Background(), sess, channel, 0)
 	require.NoError(t, err)
-	assert.Equal(t, 2, beaconCount, "expected exactly 2 beacon calls")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&beaconCount), "expected exactly 2 beacon calls")
 }
 
-// TestProbeBeacon_Error verifies that ProbeBeacon returns an error when the
-// fake transport returns a non-2xx response for the beacon call.
+// TestProbeBeacon_Error verifies that ProbeBeacon returns an error when
+// the Spade beacon transport returns a non-204 response.
 func TestProbeBeacon_Error(t *testing.T) {
+	const channel = "testchannel"
 	callCount := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>"spade_url": "` + srvBase() + `/spade"</html>`))
+	})
+	mux.HandleFunc("/spade", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
-		// First call is CurrentUser (resolveUserID); return a valid user.
-		// Subsequent calls are beacon mutations — return 500.
-		if callCount == 1 {
-			_, _ = w.Write([]byte(`{"data":{"currentUser":{"id":"99999"}}}`))
-			return
-		}
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"errors":[{"message":"internal server error"}]}`))
-	}))
+	})
+	srv = httptest.NewServer(mux)
 	defer srv.Close()
 
 	b := newForTest(srv.URL)
+	b.watch.cachedUserID = 12345 // skip CurrentUser
 	sess := platform.Session{AccessToken: "tok-probe"}
-	err := b.ProbeBeacon(context.Background(), sess, "testchannel", 0)
+	err := b.ProbeBeacon(context.Background(), sess, channel, 0)
 	require.Error(t, err, "expected error when beacon returns 5xx")
 }
 
-// TestProbeBeacon_Timeout verifies that ProbeBeacon respects context cancellation
-// during the inter-beacon sleep.
+// TestProbeBeacon_Timeout verifies that ProbeBeacon respects context
+// cancellation during the inter-beacon sleep.
 func TestProbeBeacon_Timeout(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// All calls return a valid beacon response; timeout fires during the sleep.
-		_, _ = w.Write([]byte(`{"data":{"sendSpadeEvents":{"statusCode":204}}}`))
-	}))
+	const channel = "testchannel"
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>"spade_url": "` + srvBase() + `/spade"</html>`))
+	})
+	mux.HandleFunc("/spade", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent) // first beacon succeeds
+	})
+	srv = httptest.NewServer(mux)
 	defer srv.Close()
 
 	b := newForTest(srv.URL)
-	// Pre-populate cachedUserID to skip CurrentUser; we want the timeout to
-	// fire during the inter-beacon sleep, not during a CurrentUser call.
-	b.watch.cachedUserID = 12345
+	b.watch.cachedUserID = 12345 // skip CurrentUser so timeout fires during the sleep
 	sess := platform.Session{AccessToken: "tok-probe"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
 
 	// Very long interval — context should cancel during the sleep between beacons.
-	err := b.ProbeBeacon(ctx, sess, "testchannel", 10*time.Second)
+	err := b.ProbeBeacon(ctx, sess, channel, 10*time.Second)
 	require.Error(t, err, "expected context cancellation error")
 }

--- a/internal/platform/twitch/watch.go
+++ b/internal/platform/twitch/watch.go
@@ -1,10 +1,7 @@
 package twitch
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -14,21 +11,24 @@ import (
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
-const sendEventsMutation = `mutation SendEvents($input: SendSpadeEventsInput!) {
-  sendSpadeEvents(input: $input) {
-    statusCode
-  }
-}`
-
 type watch struct {
 	c *client
 
 	userIDMu     sync.Mutex
 	cachedUserID int64
+
+	// spadeMu guards spadeURLs, a per-channel cache of the Spade
+	// minute-watched beacon URL. The beacon URL is scraped from each
+	// channel's page (see client.resolveSpadeURL) and is stable for the
+	// channel, so it's worth caching to avoid an extra HTTP GET per
+	// heartbeat. An entry is evicted on a failed beacon so the next
+	// heartbeat re-resolves from a fresh page fetch.
+	spadeMu   sync.Mutex
+	spadeURLs map[string]string
 }
 
 func newWatch() *watch {
-	return &watch{c: newClient()}
+	return &watch{c: newClient(), spadeURLs: map[string]string{}}
 }
 
 type watchInternal struct {
@@ -42,8 +42,8 @@ type watchInternal struct {
 }
 
 func (w *watch) start(ctx context.Context, sess platform.Session, stream platform.Stream) (platform.WatchHandle, error) {
-	// SendEvents tracks watch time against the broadcaster + game IDs
-	// — propagate from stream metadata.
+	// The minute-watched heartbeat is tracked against the broadcaster +
+	// game IDs — propagate them from stream metadata.
 	userID, err := w.resolveUserID(ctx, sess)
 	if err != nil {
 		return platform.WatchHandle{}, fmt.Errorf("resolve user id: %w", err)
@@ -64,8 +64,9 @@ func (w *watch) start(ctx context.Context, sess platform.Session, stream platfor
 
 // resolveUserID returns the authenticated user's Twitch numeric id.
 // Cached on the watch struct because it doesn't change for the
-// lifetime of a session. SendEvents needs this number for every
-// heartbeat — without it watch time is silently discarded.
+// lifetime of a session. The Spade minute-watched heartbeat needs this
+// number in its properties — without it watch time is silently
+// discarded.
 func (w *watch) resolveUserID(ctx context.Context, sess platform.Session) (int64, error) {
 	w.userIDMu.Lock()
 	defer w.userIDMu.Unlock()
@@ -92,12 +93,89 @@ func (w *watch) resolveUserID(ctx context.Context, sess platform.Session) (int64
 	return id, nil
 }
 
+// heartbeat sends one minute-watched event to Twitch's Spade analytics
+// beacon. As of the 2026-07-11 Twitch change, the GQL SendEvents mutation
+// is no longer credited for drop progress — only this Spade POST path
+// accrues watch time. The beacon URL is resolved per channel (cached),
+// and on a failed send the cache entry is evicted and re-resolved once
+// before giving up, mirroring twitch-gql-rs' send_watch retry.
 func (w *watch) heartbeat(ctx context.Context, h platform.WatchHandle) error {
 	internal, ok := h.Internal.(watchInternal)
 	if !ok {
 		return fmt.Errorf("invalid watch handle")
 	}
 
+	events, err := minuteWatchedEvents(internal)
+	if err != nil {
+		return err
+	}
+
+	spadeURL, err := w.cachedSpadeURL(ctx, internal.Token, internal.Channel)
+	if err != nil {
+		return fmt.Errorf("resolve spade url: %w", err)
+	}
+
+	if err := w.c.sendSpadeBeacon(ctx, internal.Token, spadeURL, events); err == nil {
+		return nil
+	}
+
+	// Evict and re-resolve once: the cached URL can go stale (Twitch
+	// rotates the analytics edge) and a fresh page fetch is the fix.
+	w.evictSpadeURL(internal.Channel)
+	spadeURL, err = w.c.resolveSpadeURL(ctx, internal.Token, internal.Channel)
+	if err != nil {
+		return fmt.Errorf("resolve spade url (retry): %w", err)
+	}
+	w.setSpadeURL(internal.Channel, spadeURL)
+	return w.c.sendSpadeBeacon(ctx, internal.Token, spadeURL, events)
+}
+
+func (w *watch) stop(_ context.Context, _ platform.WatchHandle) error {
+	return nil
+}
+
+// cachedSpadeURL returns the channel's beacon URL from the cache,
+// resolving + caching it on first use.
+func (w *watch) cachedSpadeURL(ctx context.Context, token, channel string) (string, error) {
+	w.spadeMu.Lock()
+	if u, ok := w.spadeURLs[channel]; ok {
+		w.spadeMu.Unlock()
+		return u, nil
+	}
+	w.spadeMu.Unlock()
+
+	u, err := w.c.resolveSpadeURL(ctx, token, channel)
+	if err != nil {
+		return "", err
+	}
+	w.setSpadeURL(channel, u)
+	return u, nil
+}
+
+func (w *watch) setSpadeURL(channel, spadeURL string) {
+	w.spadeMu.Lock()
+	// Lazy-init: Backend/BrowserBackend construct *watch via struct
+	// literal (&watch{c: c}) without initializing spadeURLs, so the map
+	// can be nil here. Writing to a nil map panics, so allocate on first use.
+	if w.spadeURLs == nil {
+		w.spadeURLs = map[string]string{}
+	}
+	w.spadeURLs[channel] = spadeURL
+	w.spadeMu.Unlock()
+}
+
+func (w *watch) evictSpadeURL(channel string) {
+	w.spadeMu.Lock()
+	delete(w.spadeURLs, channel)
+	w.spadeMu.Unlock()
+}
+
+// minuteWatchedEvents builds the Spade minute-watched event array for
+// the given watch handle and returns its JSON encoding. The properties
+// schema matches the post-2026-07-11 Twitch edge: game/game_id/
+// is_live/minutes_logged are required (Twitch silently discards
+// heartbeats missing them); the legacy location/player fields are gone.
+func minuteWatchedEvents(internal watchInternal) ([]byte, error) {
 	event := map[string]any{
 		"event": "minute-watched",
 		"properties": map[string]any{
@@ -116,37 +194,5 @@ func (w *watch) heartbeat(ctx context.Context, h platform.WatchHandle) error {
 			"user_id":        internal.UserID,
 		},
 	}
-	plain, err := json.Marshal([]any{event})
-	if err != nil {
-		return err
-	}
-
-	var gz bytes.Buffer
-	gw := gzip.NewWriter(&gz)
-	if _, err := gw.Write(plain); err != nil {
-		return err
-	}
-	if err := gw.Close(); err != nil {
-		return err
-	}
-	encoded := base64.StdEncoding.EncodeToString(gz.Bytes())
-
-	variables := map[string]any{
-		"input": map[string]any{
-			"data":       encoded,
-			"repository": "twilight",
-			"encoding":   "GZIP_B64",
-		},
-	}
-
-	var resp struct {
-		SendSpadeEvents struct {
-			StatusCode int `json:"statusCode"`
-		} `json:"sendSpadeEvents"`
-	}
-	return w.c.gqlQuery(ctx, internal.Token, "SendEvents", sendEventsMutation, variables, &resp)
-}
-
-func (w *watch) stop(_ context.Context, _ platform.WatchHandle) error {
-	return nil
+	return json.Marshal([]any{event})
 }

--- a/internal/platform/twitch/watch_test.go
+++ b/internal/platform/twitch/watch_test.go
@@ -1,14 +1,13 @@
 package twitch
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -18,183 +17,183 @@ import (
 	"github.com/aalejandrofer/grubdrops/internal/platform"
 )
 
-func TestWatch_HeartbeatSendsAuthHeader(t *testing.T) {
-	var gotAuth string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		_, _ = w.Write([]byte(`{"data":{"sendSpadeEvents":{"statusCode":204}}}`))
-	}))
-	defer srv.Close()
-
+// spadeTestClient builds a *client whose homeURL + http client point at
+// the test server, so both the channel-page GET (resolveSpadeURL) and
+// the beacon POST (sendSpadeBeacon) hit the same httptest server.
+func spadeTestClient(t *testing.T, srv *httptest.Server) *client {
+	t.Helper()
 	c := newTestClient(srv.URL)
-	wt := &watch{c: c, cachedUserID: 12345} // skip CurrentUser fetch
-	h, err := wt.start(context.Background(), platform.Session{AccessToken: "tok123"},
-		platform.Stream{Channel: "fakestreamer"})
-	require.NoError(t, err)
-	require.NoError(t, wt.heartbeat(context.Background(), h))
-
-	require.Equal(t, "OAuth tok123", gotAuth)
+	c.homeURL = srv.URL
+	return c
 }
 
-// TestWatch_HeartbeatBeaconShapeGolden is a regression guard for the full
-// beacon request shape. It pins everything the two focused tests above do NOT
-// already assert:
-//
-//   - HTTP method (POST) and Content-Type (text/plain;charset=UTF-8)
-//   - Required identity headers: Client-Id (Android app ID), User-Agent
-//   - Non-persisted body: query field present (mutation text), no extensions.persistedQuery
-//   - Decoded event properties: user_id, is_live, logged_in, minutes_logged,
-//     channel_id, broadcast_id
-//
-// The test passes immediately because it guards existing behaviour — that is
-// intentional for a regression guard. A future change that accidentally alters
-// the mutation text, removes an identity header, or drops a required event
-// property will cause this test to fail.
-func TestWatch_HeartbeatBeaconShapeGolden(t *testing.T) {
-	var captured struct {
-		method      string
-		contentType string
-		clientID    string
-		userAgent   string
-		body        []byte
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		captured.method = r.Method
-		captured.contentType = r.Header.Get("Content-Type")
-		captured.clientID = r.Header.Get("Client-Id")
-		captured.userAgent = r.Header.Get("User-Agent")
-		captured.body, _ = io.ReadAll(r.Body)
-		_, _ = w.Write([]byte(`{"data":{"sendSpadeEvents":{"statusCode":204}}}`))
-	}))
-	defer srv.Close()
-
+// TestWatch_HeartbeatPostsSpadeBeacon is the core regression test for
+// the 2026-07-11 Twitch API change: drop progress now requires a Spade
+// beacon POST, not the GQL SendEvents mutation. It pins the request
+// shape against the proven twitch-gql-rs send_watch:
+//   - method POST, Content-Type application/x-www-form-urlencoded
+//   - body form shape data=<urlencoded-base64-of-json> (NO gzip, NO
+//     twilight/GZIP_B64 envelope)
+//   - success on HTTP 204
+func TestWatch_HeartbeatPostsSpadeBeacon(t *testing.T) {
 	const (
+		wantChannel     = "goldenstreamer"
 		wantChannelID   = "chan99"
 		wantBroadcastID = "bcast42"
 		wantUserID      = int64(12345)
-		wantChannel     = "goldenstreamer"
+		wantGame        = "Some Game"
+		wantGameID      = "game7"
 	)
 
-	c := newTestClient(srv.URL)
-	wt := &watch{c: c, cachedUserID: wantUserID}
+	var beacon struct {
+		method      string
+		contentType string
+		auth        string
+		body        string
+	}
+	// srv is assigned below; the handler closures capture this var (not
+	// its value), so they see the final URL once httptest has bound a port.
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	// Channel page: serve HTML that inlines the spade_url.
+	mux.HandleFunc("/"+wantChannel, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `<html>"spade_url": "`+srvBase()+`/spade"</html>`)
+	})
+	// Spade beacon endpoint.
+	mux.HandleFunc("/spade", func(w http.ResponseWriter, r *http.Request) {
+		beacon.method = r.Method
+		beacon.contentType = r.Header.Get("Content-Type")
+		beacon.auth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		beacon.body = string(b)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := spadeTestClient(t, srv)
+	wt := &watch{c: c, cachedUserID: wantUserID, spadeURLs: map[string]string{}}
 	h, err := wt.start(context.Background(), platform.Session{AccessToken: "tokgolden"},
 		platform.Stream{
 			Channel:     wantChannel,
 			ChannelID:   wantChannelID,
 			BroadcastID: wantBroadcastID,
+			Game:        wantGame,
+			GameID:      wantGameID,
 		})
 	require.NoError(t, err)
 	require.NoError(t, wt.heartbeat(context.Background(), h))
 
-	// ── HTTP transport ────────────────────────────────────────────────────────
-	assert.Equal(t, http.MethodPost, captured.method, "beacon must be POST")
-	assert.Equal(t, "text/plain;charset=UTF-8", captured.contentType,
-		"Content-Type must be text/plain;charset=UTF-8 (matches Android client profile)")
+	// ── Transport shape (the thing that broke) ───────────────────────────────
+	assert.Equal(t, http.MethodPost, beacon.method, "beacon must be POST")
+	assert.Equal(t, "application/x-www-form-urlencoded", beacon.contentType,
+		"Content-Type must be application/x-www-form-urlencoded (the 2026-07-11 fix)")
+	assert.Equal(t, "OAuth tokgolden", beacon.auth, "beacon must carry the OAuth token")
 
-	// ── Identity headers ─────────────────────────────────────────────────────
-	assert.Equal(t, clientID, captured.clientID,
-		"Client-Id must be the Android app client ID")
-	assert.Equal(t, userAgent, captured.userAgent,
-		"User-Agent must be the Android Dalvik user-agent")
+	// Body is a single data= form field.
+	form, err := url.ParseQuery(beacon.body)
+	require.NoError(t, err, "body must be a valid form-encoded string")
+	require.Len(t, form, 1, "body must have exactly one field: data")
+	b64 := form.Get("data")
+	require.NotEmpty(t, b64, "data field must be present")
 
-	// ── Envelope: non-persisted shape ────────────────────────────────────────
-	var envelope map[string]json.RawMessage
-	require.NoError(t, json.Unmarshal(captured.body, &envelope), "body must be valid JSON")
-
-	// Must carry the full mutation query text, NOT a persisted-query hash.
-	var queryStr string
-	require.NoError(t, json.Unmarshal(envelope["query"], &queryStr), "query field must be a string")
-	assert.True(t, strings.Contains(queryStr, "sendSpadeEvents"),
-		"query must contain the sendSpadeEvents mutation")
-	assert.True(t, strings.Contains(queryStr, "SendEvents"),
-		"query must declare mutation SendEvents")
-	_, hasExtensions := envelope["extensions"]
-	assert.False(t, hasExtensions,
-		"non-persisted gqlQuery must NOT include extensions.persistedQuery")
-
-	// ── Decoded event properties ──────────────────────────────────────────────
-	var req struct {
-		Variables struct {
-			Input struct {
-				Data string `json:"data"`
-			} `json:"input"`
-		} `json:"variables"`
-	}
-	require.NoError(t, json.Unmarshal(captured.body, &req))
-
-	raw, err := base64.StdEncoding.DecodeString(req.Variables.Input.Data)
-	require.NoError(t, err)
-	gr, err := gzip.NewReader(bytes.NewReader(raw))
-	require.NoError(t, err)
-	plain, err := io.ReadAll(gr)
-	require.NoError(t, err)
+	// Decoded payload is plain base64 of a JSON array — NOT gzip.
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	require.NoError(t, err, "data must be valid base64")
 
 	var events []map[string]any
-	require.NoError(t, json.Unmarshal(plain, &events))
+	require.NoError(t, json.Unmarshal(raw, &events), "decoded data must be plain JSON (no gzip)")
 	require.Len(t, events, 1)
+	assert.Equal(t, "minute-watched", events[0]["event"])
 
 	props, ok := events[0]["properties"].(map[string]any)
 	require.True(t, ok, "event must have a properties object")
 
 	// Required accrual fields — Twitch silently discards heartbeats without these.
-	assert.EqualValues(t, wantUserID, props["user_id"],
-		"user_id must match the authenticated user's numeric Twitch ID")
-	assert.Equal(t, wantChannelID, props["channel_id"],
-		"channel_id must be propagated from stream metadata")
-	assert.Equal(t, wantBroadcastID, props["broadcast_id"],
-		"broadcast_id must be propagated from stream metadata")
-	assert.EqualValues(t, 1, props["minutes_logged"],
-		"minutes_logged must be 1 per heartbeat")
-	assert.Equal(t, true, props["is_live"],
-		"is_live must be true for live-stream heartbeats")
-	assert.Equal(t, true, props["logged_in"],
-		"logged_in must be true for authenticated sessions")
+	assert.EqualValues(t, wantUserID, props["user_id"], "user_id must be the numeric Twitch ID")
+	assert.Equal(t, wantChannelID, props["channel_id"], "channel_id from stream metadata")
+	assert.Equal(t, wantBroadcastID, props["broadcast_id"], "broadcast_id from stream metadata")
+	assert.Equal(t, wantGame, props["game"], "game from stream metadata")
+	assert.Equal(t, wantGameID, props["game_id"], "game_id from stream metadata")
+	assert.EqualValues(t, 1, props["minutes_logged"], "minutes_logged must be 1")
+	assert.Equal(t, true, props["is_live"], "is_live must be true")
+	assert.Equal(t, true, props["logged_in"], "logged_in must be true")
+
+	// The legacy envelope is gone — body is form-encoded, not a GQL JSON envelope.
+	assert.NotContains(t, beacon.body, "sendSpadeEvents",
+		"heartbeat must NOT use the GQL SendEvents mutation (Twitch stopped crediting it)")
+	assert.NotContains(t, beacon.body, "GZIP_B64",
+		"heartbeat must NOT use the gzip/twilight envelope")
 }
 
-func TestWatch_HeartbeatSendsGzippedBase64Mutation(t *testing.T) {
-	var got struct {
-		body []byte
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got.body, _ = io.ReadAll(r.Body)
-		_, _ = w.Write([]byte(`{"data":{"sendSpadeEvents":{"statusCode":204}}}`))
-	}))
+// TestWatch_HeartbeatRetriesAfterFailedBeacon verifies the cache-evict
+// + re-resolve + retry path: a first beacon failure triggers a fresh
+// resolveSpadeURL, and the second beacon attempt succeeds.
+func TestWatch_HeartbeatRetriesAfterFailedBeacon(t *testing.T) {
+	const channel = "retrystreamer"
+	// srv is assigned below; the handler closures capture this var (not
+	// its value), so they see the final URL once httptest has bound a port.
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	beaconHits := 0
+	pageHits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+		pageHits++
+		endpoint := "/spade"
+		if pageHits == 1 {
+			endpoint = "/spade-stale"
+		}
+		_, _ = io.WriteString(w, `<html>"spade_url": "`+srvBase()+endpoint+`"</html>`)
+	})
+	mux.HandleFunc("/spade-stale", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError) // first beacon fails
+	})
+	mux.HandleFunc("/spade", func(w http.ResponseWriter, r *http.Request) {
+		beaconHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv = httptest.NewServer(mux)
 	defer srv.Close()
 
-	c := newTestClient(srv.URL)
-	wt := &watch{c: c, cachedUserID: 12345}
+	c := spadeTestClient(t, srv)
+	wt := &watch{c: c, cachedUserID: 12345, spadeURLs: map[string]string{}}
 	h, err := wt.start(context.Background(), platform.Session{AccessToken: "tok"},
-		platform.Stream{Channel: "fakestreamer"})
+		platform.Stream{Channel: channel, ChannelID: "c1", BroadcastID: "b1"})
 	require.NoError(t, err)
-
 	require.NoError(t, wt.heartbeat(context.Background(), h))
 
-	var req struct {
-		OperationName string `json:"operationName"`
-		Variables     struct {
-			Input struct {
-				Data       string `json:"data"`
-				Repository string `json:"repository"`
-				Encoding   string `json:"encoding"`
-			} `json:"input"`
-		} `json:"variables"`
-	}
-	require.NoError(t, json.Unmarshal(got.body, &req))
-	assert.Equal(t, "SendEvents", req.OperationName)
-	assert.Equal(t, "twilight", req.Variables.Input.Repository)
-	assert.Equal(t, "GZIP_B64", req.Variables.Input.Encoding)
+	assert.Equal(t, 1, beaconHits, "the second (fresh) beacon should succeed")
+	// The stale URL was cached then evicted; the cache now holds the fresh one.
+	wt.spadeMu.Lock()
+	cached := wt.spadeURLs[channel]
+	wt.spadeMu.Unlock()
+	assert.True(t, strings.HasSuffix(cached, "/spade"), "cache should hold the fresh /spade URL")
+}
 
-	raw, err := base64.StdEncoding.DecodeString(req.Variables.Input.Data)
-	require.NoError(t, err)
-	gr, err := gzip.NewReader(bytes.NewReader(raw))
-	require.NoError(t, err)
-	plain, err := io.ReadAll(gr)
-	require.NoError(t, err)
+// TestWatch_HeartbeatFailsOnNon204 confirms a persistently-failing
+// beacon (both attempts) surfaces an error rather than silently
+// succeeding.
+func TestWatch_HeartbeatFailsOnNon204(t *testing.T) {
+	const channel = "deadstreamer"
+	var srv *httptest.Server
+	srvBase := func() string { return srv.URL }
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `<html>"spade_url": "`+srvBase()+`/spade"</html>`)
+	})
+	mux.HandleFunc("/spade", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
 
-	var events []map[string]any
-	require.NoError(t, json.Unmarshal(plain, &events))
-	require.Len(t, events, 1)
-	assert.Equal(t, "minute-watched", events[0]["event"])
-	props := events[0]["properties"].(map[string]any)
-	assert.Equal(t, "fakestreamer", props["channel"])
+	c := spadeTestClient(t, srv)
+	wt := &watch{c: c, cachedUserID: 12345, spadeURLs: map[string]string{}}
+	h, err := wt.start(context.Background(), platform.Session{AccessToken: "tok"},
+		platform.Stream{Channel: channel})
+	require.NoError(t, err)
+	err = wt.heartbeat(context.Background(), h)
+	require.Error(t, err, "both beacon attempts failed — heartbeat must error")
 }


### PR DESCRIPTION
## Problem

As of ~2026-07-11, Twitch stopped crediting drop progress for minute-watched heartbeats sent through the GQL `SendEvents` mutation. GrubDrops was sending them exactly that way (`internal/platform/twitch/watch.go`), so drops stopped progressing — the HTTP transport returned success, but no watch-time was accrued. This mirrors the same change made in `twitch-gql-rs` ([d68fda6](https://github.com/this-is-really/twitch-gql-rs/commit/d68fda6ea2213eddad2a265840366fbe7b02cac1)) and announced in TwitchDropSentryMulti ([ef22e41](https://github.com/this-is-really/TwitchDropSentryMulti/commit/ef22e41f3f17808ba2497fa21a041242d7d1abca)).

## Fix

Replace the GQL `SendEvents` mutation with the Spade beacon POST Twitch now requires:

- **`client.go`** — `resolveSpadeURL` scrapes the per-channel beacon URL from the channel page (`GET https://www.twitch.tv/<channel>`), with a fallback to the hashed `settings.<hex>.js` bundle (same two-regex pattern as the reference). `sendSpadeBeacon` POSTs `data=<urlencoded-base64-of-json>` with `Content-Type: application/x-www-form-urlencoded`, expecting HTTP 204. **No gzip, no `twilight`/`GZIP_B64` envelope** — plain base64 of raw JSON, matching the proven fix.
- **`watch.go`** — `heartbeat` resolves + caches the Spade URL per channel, evicts and re-resolves once on a failed beacon (matches the reference retry behavior). The event payload already carried `game`/`game_id`/`is_live`/`minutes_logged`, so only the transport changed. Both the direct `Backend` and `BrowserBackend` share the `*watch` struct, so both paths are fixed by this change.
- **`ops.go`** — removed the now-dead `minuteWatchedURL` constant.

## Verification

- ✅ `go build ./...`, `go vet ./...` — clean
- ✅ `go test ./...` — full suite passes; `watch_test.go` / `probe_test.go` / `canary` tests rewritten to pin the new transport shape (POST, `application/x-www-form-urlencoded`, plain base64 — no gzip, no GQL envelope), the retry-after-failure path, and the spade-URL resolver (inline + settings.js fallback + not-found)
- ✅ **Live verification**: built and ran against a real Twitch account on an active drops campaign — drop progress advanced as expected, confirming Twitch credits the Spade beacon path.

## Bonus: `cmd/keygen`

A second commit adds a tiny `go run ./cmd/keygen` utility that emits a correctly-formatted age identity for `GRUB_MASTER_KEY`. The compose README currently suggests `head -c32 /dev/urandom | base64`, which produces a base64 blob that fails `age.ParseX25519Identity` and crashes the miner at startup. This reuses `filippo.io/age` (already a dependency) to emit a valid key. Unrelated to the Twitch fix — happy to drop it from this PR if you'd prefer it separate.

## Commits

1. `fix(twitch): send minute-watched heartbeat via Spade beacon, not GQL SendEvents`
2. `feat(cmd/keygen): generate a correctly-formatted age GRUB_MASTER_KEY`