### PR TITLE
fix(watcher): persist ghost-skipped benefits across restarts + diagnostics

### DIFF
--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -439,6 +439,7 @@ func run() error {
 		// reloading takes effect. See ForceLinked in watcher.Config.
 		forceLinked := loadLinkOverrides(ctx, q)
 		forceCollected := loadCollectOverrides(ctx, q)
+		persistedSkips, skipRecorder := loadSkipOverrides(ctx, q)
 
 		acctLabel := a.DisplayName
 		w := watcher.New(watcher.Config{
@@ -458,6 +459,8 @@ func run() error {
 			ClaimRecorder:  claimRecorder,
 			ForceLinked:    forceLinked,
 			ForceCollected: forceCollected,
+			PersistedSkips: persistedSkips,
+			SkipRecorder:   skipRecorder,
 			ForceWatcher:   forceWatchStore{q: q},
 		})
 		return scheduler.NewEntry(a.ID, w), nil
@@ -750,6 +753,58 @@ func loadCollectOverrides(ctx context.Context, q *gen.Queries) func(accountID, b
 		return nil
 	}
 	return func(accountID, benefitID string) bool { return set[benefitID+":"+accountID] }
+}
+
+// loadSkipOverrides reads the ghost-skip assertions from kv (keys prefixed
+// store.SkipOverridePrefix) and returns two closures:
+//
+//   - persistedSkips(accountID): returns the set of benefit IDs previously
+//     recorded as skipped for this account. The watcher seeds its
+//     skippedBenefits map with this at New() time, so a freshly-started
+//     watcher already knows about prior skips.
+//   - skipRecorder(accountID, benefitID): writes a new skip row so the next
+//     process start re-loads it.
+//
+// Both encode the key as SkipOverridePrefix + benefitID + ":" + accountID,
+// mirroring the collect_override convention. *gen.Queries wraps *sql.DB
+// which is goroutine-safe, so the build-time q can be reused from the
+// watcher goroutine. A read failure degrades to "no prior skips" (legacy
+// restart behavior); a write failure is surfaced by the watcher, which
+// logs it and continues with the in-memory skip for this run.
+func loadSkipOverrides(ctx context.Context, q *gen.Queries) (
+	persistedSkips func(accountID string) (map[string]bool, error),
+	skipRecorder func(accountID, benefitID string) error,
+) {
+	set := map[string]bool{}
+	rows, err := q.ListKVByPrefix(ctx, sql.NullString{String: store.SkipOverridePrefix, Valid: true})
+	if err == nil {
+		for _, kv := range rows {
+			if string(kv.Value) != "1" {
+				continue
+			}
+			set[strings.TrimPrefix(kv.Key, store.SkipOverridePrefix)] = true
+		}
+	}
+	persistedSkips = func(accountID string) (map[string]bool, error) {
+		out := map[string]bool{}
+		for k := range set {
+			// k = benefitID + ":" + accountID
+			benefitID, acc, ok := strings.Cut(k, ":")
+			if !ok || acc != accountID {
+				continue
+			}
+			out[benefitID] = true
+		}
+		return out, nil
+	}
+	skipRecorder = func(accountID, benefitID string) error {
+		key := store.SkipOverridePrefix + benefitID + ":" + accountID
+		return q.UpsertSettingString(context.Background(), gen.UpsertSettingStringParams{
+			Key:   key,
+			Value: []byte("1"),
+		})
+	}
+	return persistedSkips, skipRecorder
 }
 
 type indirectNotifier struct {

--- a/internal/store/campaign_persister.go
+++ b/internal/store/campaign_persister.go
@@ -23,6 +23,15 @@ const LinkOverridePrefix = "link_override:"
 // removes a claim the user manually asserted.
 const CollectOverridePrefix = "collect_override:"
 
+// SkipOverridePrefix keys a watcher ghost-skip assertion in kv. Full key:
+// SkipOverridePrefix + benefitID + ":" + accountID, value "1". The watcher's
+// ghost-skip path (drop never appears in dropCampaignsInProgress) writes one
+// of these per skipped benefit so the skip survives process/container restarts
+// — without it, every restart re-picks already-completed drops and burns
+// ~6 min of watch time per drop before the in-memory skip fires again. The
+// watcher pre-loads these into its skippedBenefits set at New() time.
+const SkipOverridePrefix = "skip_override:"
+
 // CampaignPersister upserts every Campaign + Benefit the watcher discovers
 // into the local DB so the /drops page can render past + current +
 // upcoming tabs even before anything has been claimed.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -120,6 +120,20 @@ type Config struct {
 	// manual mark-collected control.
 	ForceCollected func(accountID, benefitID string) bool
 
+	// SkipRecorder, when set, persists a benefit the watcher has given up on
+	// (ghost-skip: the drop never appeared in dropCampaignsInProgress, usually
+	// because it was already claimed). The in-memory skippedBenefits set dies
+	// on restart; this callback writes the skip to durable storage (kv) so the
+	// next process start re-loads it via PersistedSkips and skips re-mining the
+	// same completed drop. Best-effort — errors are logged, never fatal.
+	SkipRecorder func(accountID, benefitID string) error
+
+	// PersistedSkips, when set, returns the set of benefit IDs previously
+	// recorded via SkipRecorder for this account. Seeded into skippedBenefits
+	// at New() so a freshly-started watcher already knows about prior skips
+	// without burning a watch cycle to rediscover them. Nil = no prior skips.
+	PersistedSkips func(accountID string) (map[string]bool, error)
+
 	// ForceWatcher supplies the account's force-watch channel (channel-points
 	// 24/7 idle mining) when the account is otherwise idle. Nil disables the
 	// feature. LOWEST priority: only consulted from the idle branch, and the
@@ -248,6 +262,19 @@ func New(cfg Config) *Watcher {
 		cfg.Session.GameFilter = cfg.AllowGame
 	}
 	w := &Watcher{cfg: cfg, state: StateIdle, lastNotifiedMilestone: -1}
+	// Pre-load persisted ghost-skips so a freshly-started watcher already
+	// knows which completed drops to avoid. Without this, every restart
+	// re-picks already-claimed drops and burns ~6 min of watch time per
+	// drop before the in-memory skip fires. Best-effort — a load failure
+	// degrades to "no prior skips" (the legacy restart behavior).
+	if cfg.PersistedSkips != nil {
+		if skips, err := cfg.PersistedSkips(cfg.AccountID); err == nil && len(skips) > 0 {
+			w.skippedBenefits = make(map[string]struct{}, len(skips))
+			for id := range skips {
+				w.skippedBenefits[id] = struct{}{}
+			}
+		}
+	}
 	// Register PubSub hooks BEFORE the first ListActiveCampaigns call so
 	// the backend's lazy PubSub bootstrap picks them up. Backends that
 	// don't implement PubSubAware (Kick, mock) silently skip this.
@@ -460,6 +487,21 @@ func (w *Watcher) stopCurrentWatch(ctx context.Context) {
 	_ = w.cfg.Backend.StopWatch(ctx, *handle)
 	if cs, ok := w.cfg.Backend.(platform.ChannelSubscriber); ok && channelID != "" {
 		cs.UnsubscribeChannel(w.cfg.AccountID, channelID)
+	}
+}
+
+// recordSkip persists a ghost-skip to durable storage so it survives the
+// process/container restart that would otherwise wipe the in-memory
+// skippedBenefits set. Best-effort: a recorder error is logged and never
+// fatal — the in-memory skip still applies for this run.
+func (w *Watcher) recordSkip(ctx context.Context, benefitID, benefitName string) {
+	if w.cfg.SkipRecorder == nil {
+		return
+	}
+	if err := w.cfg.SkipRecorder(w.cfg.AccountID, benefitID); err != nil {
+		slog.Warn("watcher persist skip failed; in-memory skip still applies this run",
+			"kind", "error", "account", w.cfg.AccountID,
+			"benefit", benefitID, "benefit_name", benefitName, "err", err)
 	}
 }
 
@@ -1667,6 +1709,21 @@ func (w *Watcher) tickWatch(ctx context.Context) error {
 	// campaign-expired. Stop the watch and let pickCampaign find the
 	// next eligible target.
 	if !matched {
+		// Diagnostic: log what inventory DID return when the watched benefit
+		// isn't among it. Distinguishes "Twitch isn't reporting this drop at
+		// all" from "Twitch is reporting it under a different ID" — the key
+		// question for diagnosing drops that complete on Twitch but never
+		// appear in the bot's progress bar. DEBUG so it's off by default;
+		// raise the log level when investigating a stuck drop.
+		if len(progress) > 0 {
+			ids := make([]string, 0, len(progress))
+			for _, p := range progress {
+				ids = append(ids, fmt.Sprintf("%s(%dm)", p.BenefitID, p.MinutesWatched))
+			}
+			slog.Debug("watcher inventory did not contain watched benefit",
+				"kind", "progress", "account", w.cfg.AccountID,
+				"benefit", benefit.ID, "inventory_returned", ids)
+		}
 		w.mu.Lock()
 		w.noProgressTicks++
 		n := w.noProgressTicks
@@ -1691,6 +1748,7 @@ func (w *Watcher) tickWatch(ctx context.Context) error {
 			w.currentStream = nil
 			w.handle = nil
 			w.mu.Unlock()
+			w.recordSkip(ctx, benefit.ID, benefit.Name)
 			w.setState(ctx, StatePickCampaign)
 			return nil
 		}
@@ -1723,6 +1781,7 @@ func (w *Watcher) tickWatch(ctx context.Context) error {
 			w.currentStream = nil
 			w.handle = nil
 			w.mu.Unlock()
+			w.recordSkip(ctx, benefit.ID, benefit.Name)
 			w.setState(ctx, StatePickCampaign)
 			return nil
 		}
@@ -1892,15 +1951,27 @@ func (w *Watcher) claim(ctx context.Context) error {
 	// P6: post-claim consistency probe. Soft signal — log drift but
 	// don't roll back the claim. DropCurrentSession returning the same
 	// drop after claim means Twitch hasn't yet cleared the in-progress
-	// row; usually catches up within a few seconds.
+	// row; usually catches up within a few seconds. An empty or
+	// mismatched session is logged at DEBUG for diagnostic purposes —
+	// it's the normal post-claim state once Twitch clears the row.
 	if checker, ok := w.cfg.Backend.(platform.CurrentSessionChecker); ok {
-		if cs, err := checker.CurrentSession(ctx, w.cfg.Session); err == nil && cs.DropID == benefit.ID {
-			slog.Info("watcher post-claim: drop still in current session, server lag expected",
-				"kind", "claim",
-				"account", w.cfg.AccountID,
-				"benefit", benefit.ID,
-				"current_min", cs.CurrentMinute,
-				"required_min", cs.RequiredMinute)
+		if cs, err := checker.CurrentSession(ctx, w.cfg.Session); err == nil {
+			if cs.DropID == benefit.ID {
+				slog.Info("watcher post-claim: drop still in current session, server lag expected",
+					"kind", "claim",
+					"account", w.cfg.AccountID,
+					"benefit", benefit.ID,
+					"current_min", cs.CurrentMinute,
+					"required_min", cs.RequiredMinute)
+			} else if cs.DropID != "" {
+				slog.Debug("watcher post-claim: current session is a different drop",
+					"kind", "claim",
+					"account", w.cfg.AccountID,
+					"benefit", benefit.ID,
+					"current_session_drop", cs.DropID,
+					"current_min", cs.CurrentMinute,
+					"required_min", cs.RequiredMinute)
+			}
 		}
 	}
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -318,6 +319,155 @@ func TestWatcher_VanishDetect(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return backend.stops() >= 1
 	}, time.Second, 5*time.Millisecond, "watcher did not StopWatch after benefit vanished")
+}
+
+// ghostSkipBackend serves a campaign with two benefits but reports an
+// EMPTY in-progress inventory, so the watcher never sees either drop
+// enroll and must ghost-skip both after synthSkipThreshold ticks.
+type ghostSkipBackend struct {
+	*platformtest.MockBackend
+	mu         sync.Mutex
+	stopCalled int
+}
+
+func (g *ghostSkipBackend) ListActiveCampaigns(_ context.Context, _ platform.Session) ([]platform.Campaign, error) {
+	return []platform.Campaign{{
+		ID: "gcamp", Game: "GhostGame", Name: "Ghost Camp", Status: "active", AccountLinked: true,
+		Benefits: []platform.DropBenefit{
+			{ID: "ghost1", CampaignID: "gcamp", Name: "Ghost One", RequiredMinutes: 60},
+			{ID: "ghost2", CampaignID: "gcamp", Name: "Ghost Two", RequiredMinutes: 120},
+		},
+	}}, nil
+}
+
+func (g *ghostSkipBackend) InventoryProgress(_ context.Context, _ platform.Session) ([]platform.Progress, error) {
+	return nil, nil // never reports any in-progress drop → ghost-skip fires
+}
+
+func (g *ghostSkipBackend) StopWatch(_ context.Context, _ platform.WatchHandle) error {
+	g.mu.Lock()
+	g.stopCalled++
+	g.mu.Unlock()
+	return nil
+}
+
+func (g *ghostSkipBackend) stops() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.stopCalled
+}
+
+// recordingSkipRecorder captures every (accountID, benefitID) the watcher
+// records as a ghost-skip, so a test can assert persistence happened and
+// re-seed a fresh watcher from the same set.
+type recordingSkipRecorder struct {
+	mu   sync.Mutex
+	seen map[string]bool // key = accountID + ":" + benefitID
+}
+
+func newRecordingSkipRecorder() *recordingSkipRecorder {
+	return &recordingSkipRecorder{seen: map[string]bool{}}
+}
+
+func (r *recordingSkipRecorder) recordSkip(accountID, benefitID string) error {
+	r.mu.Lock()
+	// Match the kv convention: benefitID + ":" + accountID (see
+	// loadSkipOverrides / CollectOverridePrefix).
+	r.seen[benefitID+":"+accountID] = true
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingSkipRecorder) skips(accountID string) map[string]bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := map[string]bool{}
+	for k := range r.seen {
+		// k = benefitID + ":" + accountID
+		benefitID, acc, ok := strings.Cut(k, ":")
+		if ok && acc == accountID {
+			out[benefitID] = true
+		}
+	}
+	return out
+}
+
+// TestWatcher_GhostSkip_PersistsAcrossRestart verifies that a benefit
+// the watcher ghost-skips is (a) recorded via SkipRecorder and (b) NOT
+// re-picked after a simulated restart — a fresh watcher seeded with the
+// recorded skips via PersistedSkips must skip both ghost benefits
+// immediately rather than burning synthSkipThreshold ticks each.
+func TestWatcher_GhostSkip_PersistsAcrossRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	const accID = "acc-ghost"
+	rec := newRecordingSkipRecorder()
+	backend := &ghostSkipBackend{MockBackend: platformtest.New()}
+
+	// Phase 1: drive the first watcher. It should pick a ghost benefit,
+	// watch for synthSkipThreshold ticks, then ghost-skip it and record it.
+	w1 := New(Config{
+		AccountID:         accID,
+		Backend:           backend,
+		Session:           platform.Session{AccessToken: "tok"},
+		Notifier:          &recordingNotifier{},
+		TickInterval:      2 * time.Millisecond,
+		HeartbeatInterval: 2 * time.Millisecond,
+		SkipRecorder:      rec.recordSkip,
+	})
+	go func() { _ = w1.Run(ctx) }()
+
+	// Wait for BOTH ghost benefits to be recorded as skipped. The watcher
+	// picks ghost1, watches synthSkipThreshold ticks, skips+records it,
+	// then picks ghost2 and repeats — so we need to wait for the full
+	// cycle before snapshotting the skips for the restart simulation.
+	require.Eventually(t, func() bool {
+		return len(rec.skips(accID)) >= 2
+	}, 3*time.Second, 5*time.Millisecond,
+		"watcher never recorded both ghost-skips")
+
+	// Phase 2: simulate a restart. Build a FRESH watcher (new skippedBenefits
+	// map) seeded with the persisted skips. It must NOT pick either ghost
+	// benefit — pickCampaign's skippedBenefits filter should skip them
+	// immediately because PersistedSkips pre-seeded the set at New().
+	cancel() // stop w1 before building w2 to avoid shared-backend races
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel2()
+
+	backend2 := &ghostSkipBackend{MockBackend: platformtest.New()}
+	skipsSoFar := rec.skips(accID)
+	w2 := New(Config{
+		AccountID:         accID,
+		Backend:           backend2,
+		Session:           platform.Session{AccessToken: "tok"},
+		Notifier:          &recordingNotifier{},
+		TickInterval:      2 * time.Millisecond,
+		HeartbeatInterval: 2 * time.Millisecond,
+		PersistedSkips: func(accountID string) (map[string]bool, error) {
+			if accountID == accID {
+				return skipsSoFar, nil
+			}
+			return map[string]bool{}, nil
+		},
+	})
+	go func() { _ = w2.Run(ctx2) }()
+
+	// Give the watcher a few ticks to run a discovery + pick cycle. If the
+	// persisted skips are correctly seeded, it should NOT start watching
+	// either ghost benefit (which would be observable as a StateWatching
+	// transition or a StopWatch call after a ghost-skip).
+	time.Sleep(200 * time.Millisecond)
+
+	// The pre-seeded watcher must NOT have started watching — both benefits
+	// are in skippedBenefits, so pickCampaign skips them and the watcher
+	// sleeps with no current benefit. backend2.stops() stays 0 (no ghost-skip
+	// path fired because nothing was ever picked).
+	assert.Equal(t, 0, backend2.stops(),
+		"fresh watcher seeded with persisted skips must not watch ghost benefits")
+
+	// And both ghost benefits should be in the pre-seeded set.
+	assert.Contains(t, skipsSoFar, "ghost1", "ghost1 should have been recorded as skipped")
 }
 
 // excludeBackend returns two ACTIVE Rust campaigns; the watcher must


### PR DESCRIPTION
## Problem

After a drop is claimed (manually on twitch.tv, or by the bot), Twitch removes it from `dropCampaignsInProgress`. The watcher kept re-picking these already-completed drops on every container restart, burning ~6 min of watch time per drop before the in-memory `skippedBenefits` set kicked in again. Observed live: an account cycling through 5 completed Delta Force drops every restart (~30 min wasted before reaching anything new).

**Root cause:** the `skippedBenefits` set is in-memory only — it dies on restart. The reconcile loop that backfills the `claims` table (so `ownClaimed[]` would catch these) is gated on `claimed[]`, which is built only from `dropCampaignsInProgress`. So a completed drop is never in `claimed[]`, never reconciled, and the pick loop's `if claimed[b.ID] || ownClaimed[b.ID]` guard never fires.

## Fix

Mirrors the existing `collect_override:` kv + `ForceCollected` pattern (proven, schema-free, already wired end-to-end) with a `skip_override:` kv namespace:

- **`SkipOverridePrefix`** constant (`skip_override:`) — same key shape as `collect_override` (`benefitID:accountID`).
- **`SkipRecorder` / `PersistedSkips`** hooks on `watcher.Config`. The ghost-skip path records the skip via `SkipRecorder`; `New()` pre-loads prior skips via `PersistedSkips` so a freshly-started watcher already knows what to avoid.
- **`loadSkipOverrides`** in `cmd/miner` wires the kv read/write closures into the watcher config.

No schema changes, no migration — the `kv` table already exists. The skip is additive (only prevents re-picking) and semantically distinct from a claim (a skip means "don't try to mine this," not "this is collected"), so it doesn't pollute the Past/Collected UI.

## Diagnostics (Part B)

The deeper question — **why drops complete on Twitch but never appear in the bot's inventory poll** (so no auto-claim fires) — is still unsolved. Rather than speculatively change the completion-detection logic, this PR adds targeted logging to capture the next occurrence:

- **DEBUG in `tickWatch`**: when the watched benefit isn't in the inventory result, logs what inventory *did* return. Distinguishes "Twitch isn't reporting this drop at all" from "Twitch is reporting it under a different ID."
- **Post-claim `CurrentSession` probe**: now logs at DEBUG when the session is a *different* drop, not just when it matches. Helps see whether Twitch even considers the drop active.

Both are DEBUG/gated so they're off by default — raise the log level when investigating a stuck drop.

## Verification

- ✅ `go build ./...`, `go vet ./...` — clean
- ✅ `go test ./...` — full suite passes (fresh, no cache)
- ✅ `TestWatcher_GhostSkip_PersistsAcrossRestart` — drives a ghost-skip, records it, builds a fresh watcher seeded with the persisted skips, asserts neither ghost benefit is re-picked (`backend2.stops()` stays 0). The logs confirm the fresh watcher runs discovery → "has no eligible benefit, sleeping" without ever starting a watch.

## What this does NOT do (deliberately)

- **Does not fix the root auto-claim failure.** That needs the diagnostic logs to run in prod first, then a targeted fix once the actual failure mode is captured. I won't guess at the completion-detection logic blind.
- **No UI for managing skip overrides yet** — rare case. Can be added if it becomes useful; for now the `kv` rows are inspectable directly.

## How to clear a skip

If a drop is wrongly skipped (e.g. it becomes claimable again in a future campaign), delete the `kv` row:
```sql
DELETE FROM kv WHERE key = 'skip_override:<benefitID>:<accountID>';
```